### PR TITLE
Add image-generation task exclusion to leaderboard views

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next'
-import { fetchLeaderboard, fetchBenchmarkVersions } from '@/lib/api'
-import { calculateRanks, transformLeaderboardEntry } from '@/lib/transforms'
+import { fetchLeaderboard, fetchBenchmarkVersions, fetchSubmission } from '@/lib/api'
+import { calculateRanks, transformLeaderboardEntry, EPSILON, estimateSuccessfulTasks } from '@/lib/transforms'
+import { isExcludedLeaderboardTask } from '@/lib/task-metadata'
 import { LeaderboardView } from '@/components/leaderboard-view'
 
 interface HomeProps {
-  searchParams: Promise<{ version?: string; view?: string; official?: string }>
+  searchParams: Promise<{ version?: string; view?: string; official?: string; excludeImageGen?: string }>
 }
 
 export async function generateMetadata({ searchParams }: HomeProps): Promise<Metadata> {
@@ -42,13 +43,94 @@ export async function generateMetadata({ searchParams }: HomeProps): Promise<Met
 }
 
 export default async function Home({ searchParams }: HomeProps) {
-  const { version, official } = await searchParams
+  const { version, official, excludeImageGen } = await searchParams
   const officialOnly = official !== 'false'
+  const excludeImageGenBool = excludeImageGen === 'true'
   const [response, versionsResponse] = await Promise.all([
     fetchLeaderboard(version, { officialOnly }),
     fetchBenchmarkVersions(),
   ])
-  const entries = calculateRanks(response.leaderboard.map(transformLeaderboardEntry))
+  let transformedEntries = response.leaderboard.map(transformLeaderboardEntry)
+
+  if (excludeImageGenBool) {
+    // Fetch best submission details and adjust scores to exclude image-generation tasks.
+    const bestSubmissions = []
+    const batchSize = 10
+
+    for (let i = 0; i < transformedEntries.length; i += batchSize) {
+      const batch = transformedEntries.slice(i, i + batchSize)
+      const results = await Promise.all(
+        batch.map(entry =>
+          fetchSubmission(entry.submission_id)
+            .then(res => res.submission)
+            .catch(err => {
+              console.error('Failed to fetch submission for', entry.submission_id, err)
+              return null
+            })
+        )
+      )
+      bestSubmissions.push(...results)
+    }
+
+    const adjustedEntries = []
+
+    for (let i = 0; i < transformedEntries.length; i++) {
+      const entry = transformedEntries[i]
+      const sub = bestSubmissions[i]
+
+      // Preserve the original entry if submission details are temporarily unavailable.
+      if (!sub) {
+        adjustedEntries.push(entry)
+        continue
+      }
+
+      const excludedTasks = sub.tasks.filter(task => isExcludedLeaderboardTask(task.task_id))
+      if (excludedTasks.length === 0) {
+        adjustedEntries.push(entry)
+        continue
+      }
+
+      const excludedScore = excludedTasks.reduce((sum, task) => sum + task.score, 0)
+      const excludedMax = excludedTasks.reduce((sum, task) => sum + task.max_score, 0)
+      const remainingTaskCount = sub.tasks.filter(task => !isExcludedLeaderboardTask(task.task_id)).length
+
+      const adjustedScore = sub.total_score - excludedScore
+      const adjustedMax = sub.max_score - excludedMax
+      if (adjustedMax <= 0 || remainingTaskCount <= 0) {
+        adjustedEntries.push(entry)
+        continue
+      }
+
+      const adjustedPercentage = adjustedScore / adjustedMax
+      if (!Number.isFinite(adjustedPercentage)) {
+        adjustedEntries.push(entry)
+        continue
+      }
+
+      const bestCost = entry.best_cost_usd
+      let value_score: number | null = null
+      if (bestCost != null && bestCost > EPSILON) {
+        value_score = (adjustedPercentage * 100) / bestCost
+      }
+
+      let cpst: number | null = null
+      const successfulTasks = estimateSuccessfulTasks(adjustedPercentage, remainingTaskCount)
+      if (bestCost != null && bestCost > EPSILON && successfulTasks != null && successfulTasks > 0) {
+        cpst = bestCost / successfulTasks
+      }
+
+      adjustedEntries.push({
+        ...entry,
+        percentage: adjustedPercentage * 100,
+        value_score,
+        cpst,
+      })
+    }
+
+    transformedEntries = adjustedEntries
+  }
+
+  const entries = calculateRanks(transformedEntries)
   const latestTimestamp = entries.reduce((latest, entry) => {
     const current = new Date(entry.timestamp).getTime()
     return Number.isNaN(current) ? latest : Math.max(latest, current)
@@ -71,6 +153,7 @@ export default async function Home({ searchParams }: HomeProps) {
       versions={versionsResponse.versions}
       currentVersion={version ?? null}
       officialOnly={officialOnly}
+      excludeImageGen={excludeImageGenBool}
     />
   )
 }

--- a/app/submission/[id]/page.tsx
+++ b/app/submission/[id]/page.tsx
@@ -13,16 +13,18 @@ import { PROVIDER_COLORS } from '@/lib/types'
 import { formatDistanceToNow } from 'date-fns'
 import { fetchSubmission } from '@/lib/api'
 import { transformSubmission } from '@/lib/transforms'
+import { isExcludedLeaderboardTask } from '@/lib/task-metadata'
 
 interface SubmissionPageProps {
   params: Promise<{ id: string }>
-  searchParams: Promise<{ official?: string }>
+  searchParams: Promise<{ official?: string; excludeImageGen?: string }>
 }
 
 export default async function SubmissionPage({ params, searchParams }: SubmissionPageProps) {
   const { id } = await params
-  const { official } = await searchParams
+  const { official, excludeImageGen } = await searchParams
   const officialOnly = official !== 'false'
+  const excludeImageGenBool = excludeImageGen === 'true'
   let submission
 
   try {
@@ -68,7 +70,23 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
     notFound()
   }
 
-  const categoryStats = submission.task_results.reduce(
+  // Apply image generation exclusion if requested
+  let displayTasks = submission.task_results
+  let displayTotalScore = submission.total_score
+  let displayMaxScore = submission.max_score
+
+  if (excludeImageGenBool) {
+    const excludedTasks = submission.task_results.filter(task => isExcludedLeaderboardTask(task.task_id))
+    if (excludedTasks.length > 0) {
+      const excludedScore = excludedTasks.reduce((sum, task) => sum + task.score, 0)
+      const excludedMax = excludedTasks.reduce((sum, task) => sum + task.max_score, 0)
+      displayTotalScore = submission.total_score - excludedScore
+      displayMaxScore = submission.max_score - excludedMax
+      displayTasks = submission.task_results.filter(task => !isExcludedLeaderboardTask(task.task_id))
+    }
+  }
+
+  const categoryStats = displayTasks.reduce(
     (acc, task) => {
       if (!acc[task.category]) {
         acc[task.category] = { total: 0, max: 0, count: 0 }
@@ -191,8 +209,8 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
           <div className="lg:col-span-1">
             <ScoreGauge
-              score={submission.total_score}
-              maxScore={submission.max_score}
+              score={displayTotalScore}
+              maxScore={displayMaxScore}
             />
           </div>
 
@@ -237,10 +255,10 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
               Task Breakdown
             </h2>
             <p className="text-sm text-muted-foreground">
-              {submission.task_results.length} tasks completed
+              {displayTasks.length} tasks completed
             </p>
           </div>
-          <TaskBreakdown tasks={submission.task_results} />
+          <TaskBreakdown tasks={displayTasks} excludeImageGen={excludeImageGenBool} />
           
           {/* Hardware Info */}
           {submission.metadata.system && (
@@ -276,8 +294,6 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
           </div>
         </Card>
       </div>
-
-
     </div>
   )
 }

--- a/app/submission/[id]/page.tsx
+++ b/app/submission/[id]/page.tsx
@@ -258,7 +258,7 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
               {displayTasks.length} tasks completed
             </p>
           </div>
-          <TaskBreakdown tasks={displayTasks} excludeImageGen={excludeImageGenBool} />
+          <TaskBreakdown tasks={displayTasks} />
           
           {/* Hardware Info */}
           {submission.metadata.system && (

--- a/components/leaderboard-header.tsx
+++ b/components/leaderboard-header.tsx
@@ -19,10 +19,12 @@ interface LeaderboardHeaderProps {
     scoreMode: ScoreMode
     officialOnly: boolean
     openWeightsOnly: boolean
+    excludeImageGen?: boolean
     onViewChange: (view: ViewMode) => void
     onScoreModeChange: (mode: ScoreMode) => void
     onOfficialOnlyChange: (officialOnly: boolean) => void
     onOpenWeightsOnlyChange: (openWeightsOnly: boolean) => void
+    onExcludeImageGenChange?: (value: boolean) => void
     onClearProviderFilter: () => void
 }
 
@@ -38,10 +40,12 @@ export function LeaderboardHeader({
     scoreMode,
     officialOnly,
     openWeightsOnly,
+    excludeImageGen,
     onViewChange,
     onScoreModeChange,
     onOfficialOnlyChange,
     onOpenWeightsOnlyChange,
+    onExcludeImageGenChange,
     onClearProviderFilter,
 }: LeaderboardHeaderProps) {
     return (
@@ -110,6 +114,15 @@ export function LeaderboardHeader({
                                     className="h-3.5 w-3.5 rounded border border-border/70 bg-muted/30 text-muted-foreground checked:border-muted-foreground checked:bg-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0"
                                 />
                                 Open-weight only
+                            </label>
+                            <label className="flex items-center gap-2 text-xs text-muted-foreground/90 cursor-pointer hover:text-foreground transition-colors">
+                                <input
+                                    type="checkbox"
+                                    checked={excludeImageGen}
+                                    onChange={(e) => onExcludeImageGenChange?.(e.target.checked)}
+                                    className="h-3.5 w-3.5 rounded border border-border/70 bg-muted/30 text-muted-foreground checked:border-muted-foreground checked:bg-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0"
+                                />
+                                Exclude image generation tasks
                             </label>
                             <span className="text-xs text-muted-foreground/60">Updated {lastUpdated}</span>
                         </div>
@@ -226,6 +239,15 @@ export function LeaderboardHeader({
                             className="h-3.5 w-3.5 rounded border border-border/70 bg-muted/30 text-muted-foreground checked:border-muted-foreground checked:bg-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0"
                         />
                         Open-weight only
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer hover:text-foreground transition-colors">
+                        <input
+                            type="checkbox"
+                            checked={excludeImageGen}
+                            onChange={(e) => onExcludeImageGenChange?.(e.target.checked)}
+                            className="h-3.5 w-3.5 rounded border border-border/70 bg-muted/30 text-muted-foreground checked:border-muted-foreground checked:bg-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0"
+                        />
+                        Exclude image generation tasks
                     </label>
                     <span className="text-muted-foreground/60">Updated {lastUpdated}</span>
                 </div>

--- a/components/leaderboard-view.tsx
+++ b/components/leaderboard-view.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState, useEffect } from 'react'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
 import type { LeaderboardEntry, BenchmarkVersion } from '@/lib/types'
 import { PROVIDER_COLORS } from '@/lib/types'
@@ -25,9 +25,10 @@ interface LeaderboardViewProps {
     versions: BenchmarkVersion[]
     currentVersion: string | null
     officialOnly: boolean
+    excludeImageGen?: boolean
 }
 
-export function LeaderboardView({ entries, lastUpdated, versions, currentVersion, officialOnly }: LeaderboardViewProps) {
+export function LeaderboardView({ entries, lastUpdated, versions, currentVersion, officialOnly, excludeImageGen = false }: LeaderboardViewProps) {
     const searchParams = useSearchParams()
     const router = useRouter()
     const pathname = usePathname()
@@ -51,6 +52,7 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
     const [providerFilter, setProviderFilterState] = useState<string | null>(initialProvider)
     const [openWeightsOnly, setOpenWeightsOnlyState] = useState<boolean>(initialOpenWeights)
     const [graphSubTab, setGraphSubTabState] = useState<GraphSubTab>(initialGraphTab)
+    const [excludeImageGenLocal, setExcludeImageGenState] = useState<boolean>(excludeImageGen)
 
     // Helper to update URL params without full page reload
     const updateUrl = useCallback((updates: Record<string, string | null>) => {
@@ -94,6 +96,16 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
         updateUrl({ graph: t === 'scatter' ? null : t })
     }, [updateUrl])
 
+    const setExcludeImageGen = useCallback((v: boolean) => {
+        setExcludeImageGenState(v)
+        updateUrl({ excludeImageGen: v ? 'true' : null })
+    }, [updateUrl])
+
+    // Sync prop to local state when URL changes (e.g., browser back/forward)
+    useEffect(() => {
+        setExcludeImageGenState(excludeImageGen)
+    }, [excludeImageGen])
+
     const setOfficialOnly = useCallback((v: boolean) => {
         setOfficialOnlyState(v)
         updateUrl({ official: v ? null : 'false' })
@@ -134,10 +146,12 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                 scoreMode={scoreMode}
                 officialOnly={officialOnlyState}
                 openWeightsOnly={openWeightsOnly}
+                excludeImageGen={excludeImageGenLocal}
                 onViewChange={setView}
                 onScoreModeChange={setScoreMode}
                 onOfficialOnlyChange={setOfficialOnly}
                 onOpenWeightsOnlyChange={setOpenWeightsOnly}
+                onExcludeImageGenChange={setExcludeImageGen}
                 onClearProviderFilter={() => setProviderFilter(null)}
             />
 
@@ -169,7 +183,7 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                             <ScatterGraphs entries={filteredEntries} scoreMode={scoreMode} />
                         )}
                         {graphSubTab === 'heatmap' && (
-                            <TaskHeatmap entries={filteredEntries} scoreMode={scoreMode} />
+                            <TaskHeatmap entries={filteredEntries} scoreMode={scoreMode} excludeImageGen={excludeImageGenLocal} />
                         )}
                         {graphSubTab === 'distribution' && (
                             <ScoreDistribution entries={filteredEntries} scoreMode={scoreMode} currentVersion={currentVersion} officialOnly={officialOnlyState} />

--- a/components/task-breakdown.tsx
+++ b/components/task-breakdown.tsx
@@ -8,6 +8,7 @@ import { ColoredProgress } from '@/components/ui/colored-progress'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import type { TaskResult } from '@/lib/types'
 import { CATEGORY_ICONS } from '@/lib/types'
+import { isExcludedLeaderboardTask } from '@/lib/task-metadata'
 import {
   Collapsible,
   CollapsibleContent,
@@ -16,6 +17,7 @@ import {
 
 interface TaskBreakdownProps {
   tasks: TaskResult[]
+  excludeImageGen?: boolean
 }
 
 const getScoreColor = (score: number, maxScore: number) => {
@@ -46,7 +48,7 @@ const getGradingBadgeVariant = (
   }
 }
 
-export function TaskBreakdown({ tasks }: TaskBreakdownProps) {
+export function TaskBreakdown({ tasks, excludeImageGen = false }: TaskBreakdownProps) {
   const [openTasks, setOpenTasks] = useState<Set<string>>(new Set())
 
   const toggleTask = (taskId: string) => {
@@ -61,7 +63,7 @@ export function TaskBreakdown({ tasks }: TaskBreakdownProps) {
 
   return (
     <div className="space-y-2">
-      {tasks.map((task) => {
+      {tasks.filter(task => !(excludeImageGen && isExcludedLeaderboardTask(task.task_id))).map((task) => {
         const percentage = (task.score / task.max_score) * 100
         const isOpen = openTasks.has(task.task_id)
 

--- a/components/task-heatmap.tsx
+++ b/components/task-heatmap.tsx
@@ -71,10 +71,6 @@ export function TaskHeatmap({ entries, scoreMode, excludeImageGen = false }: Tas
                 const taskMap = new Map<string, { score: number; maxScore: number; taskName: string; category: string }>()
 
                 for (const task of submission.task_results) {
-                  if (excludeImageGen && isExcludedLeaderboardTask(task.task_id)) {
-                    continue
-                  }
-
                   taskMap.set(task.task_id, {
                     score: task.score,
                     maxScore: task.max_score,
@@ -112,7 +108,7 @@ export function TaskHeatmap({ entries, scoreMode, excludeImageGen = false }: Tas
 
     loadData()
     return () => { cancelled = true }
-  }, [entries, excludeImageGen])
+  }, [entries])
 
   // Collect all unique tasks and sort by category
   const allTasks = useMemo(() => {
@@ -127,12 +123,13 @@ export function TaskHeatmap({ entries, scoreMode, excludeImageGen = false }: Tas
 
     return Array.from(taskMap.entries())
       .map(([taskId, info]) => ({ taskId, ...info }))
+      .filter(task => !(excludeImageGen && isExcludedLeaderboardTask(task.taskId)))
       .sort((a, b) => {
         const catCmp = a.category.localeCompare(b.category)
         if (catCmp !== 0) return catCmp
         return a.taskName.localeCompare(b.taskName)
       })
-  }, [modelData])
+  }, [modelData, excludeImageGen])
 
   // Sort models
   const sortedModels = useMemo(() => {

--- a/components/task-heatmap.tsx
+++ b/components/task-heatmap.tsx
@@ -5,12 +5,14 @@ import type { LeaderboardEntry, TaskResult } from '@/lib/types'
 import { PROVIDER_COLORS, CATEGORY_ICONS } from '@/lib/types'
 import { fetchSubmissionClient } from '@/lib/api'
 import { transformSubmission } from '@/lib/transforms'
+import { isExcludedLeaderboardTask } from '@/lib/task-metadata'
 import { ShareableWrapper } from '@/components/shareable-wrapper'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 interface TaskHeatmapProps {
   entries: LeaderboardEntry[]
   scoreMode: 'best' | 'average'
+  excludeImageGen?: boolean
 }
 
 interface ModelTaskData {
@@ -37,7 +39,7 @@ function getScoreTextColor(ratio: number): string {
   return 'hsl(0, 70%, 75%)'
 }
 
-export function TaskHeatmap({ entries, scoreMode }: TaskHeatmapProps) {
+export function TaskHeatmap({ entries, scoreMode, excludeImageGen = false }: TaskHeatmapProps) {
   const [modelData, setModelData] = useState<ModelTaskData[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -69,6 +71,10 @@ export function TaskHeatmap({ entries, scoreMode }: TaskHeatmapProps) {
                 const taskMap = new Map<string, { score: number; maxScore: number; taskName: string; category: string }>()
 
                 for (const task of submission.task_results) {
+                  if (excludeImageGen && isExcludedLeaderboardTask(task.task_id)) {
+                    continue
+                  }
+
                   taskMap.set(task.task_id, {
                     score: task.score,
                     maxScore: task.max_score,
@@ -106,7 +112,7 @@ export function TaskHeatmap({ entries, scoreMode }: TaskHeatmapProps) {
 
     loadData()
     return () => { cancelled = true }
-  }, [entries])
+  }, [entries, excludeImageGen])
 
   // Collect all unique tasks and sort by category
   const allTasks = useMemo(() => {
@@ -248,133 +254,133 @@ export function TaskHeatmap({ entries, scoreMode }: TaskHeatmapProps) {
           subtitle={`${sortedModels.length} models x ${allTasks.length} tasks`}
         >
           <div className="rounded-lg border border-border bg-background overflow-x-auto">
-          <table className="text-xs border-collapse w-full" style={{ minWidth: allTasks.length * 36 + 180 }}>
-            {/* Category header row */}
-            <thead>
-              <tr>
-                <th className="sticky left-0 z-20 bg-background border-b border-r border-border p-1" />
-                {categoryGroups.map((group) => (
-                  <th
-                    key={group.category}
-                    colSpan={group.count}
-                    className="border-b border-border px-1 py-1.5 text-center font-medium text-muted-foreground bg-muted/30"
-                  >
-                    <span title={group.category} className="capitalize">
-                      {CATEGORY_ICONS[group.category] || ''} {group.category}
-                    </span>
+            <table className="text-xs border-collapse w-full" style={{ minWidth: allTasks.length * 36 + 180 }}>
+              {/* Category header row */}
+              <thead>
+                <tr>
+                  <th className="sticky left-0 z-20 bg-background border-b border-r border-border p-1" />
+                  {categoryGroups.map((group) => (
+                    <th
+                      key={group.category}
+                      colSpan={group.count}
+                      className="border-b border-border px-1 py-1.5 text-center font-medium text-muted-foreground bg-muted/30"
+                    >
+                      <span title={group.category} className="capitalize">
+                        {CATEGORY_ICONS[group.category] || ''} {group.category}
+                      </span>
+                    </th>
+                  ))}
+                </tr>
+                {/* Task name header row */}
+                <tr>
+                  <th className="sticky left-0 z-20 bg-background border-b border-r border-border p-1 text-left font-medium text-muted-foreground min-w-[180px]">
+                    Model
                   </th>
-                ))}
-              </tr>
-              {/* Task name header row */}
-              <tr>
-                <th className="sticky left-0 z-20 bg-background border-b border-r border-border p-1 text-left font-medium text-muted-foreground min-w-[180px]">
-                  Model
-                </th>
-                {allTasks.map((task) => (
-                  <th
-                    key={task.taskId}
-                    className="border-b border-border p-0 font-normal text-muted-foreground/70"
-                    style={{ width: 36, minWidth: 36, maxWidth: 36 }}
-                  >
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <div
-                          className="flex items-end justify-center overflow-hidden cursor-help"
-                          style={{ height: 80 }}
-                        >
-                          <span
-                            className="block whitespace-nowrap text-[9px] origin-bottom-left"
-                            style={{
-                              transform: 'rotate(-55deg)',
-                              transformOrigin: 'center center',
-                              maxWidth: 75,
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                            }}
+                  {allTasks.map((task) => (
+                    <th
+                      key={task.taskId}
+                      className="border-b border-border p-0 font-normal text-muted-foreground/70"
+                      style={{ width: 36, minWidth: 36, maxWidth: 36 }}
+                    >
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div
+                            className="flex items-end justify-center overflow-hidden cursor-help"
+                            style={{ height: 80 }}
                           >
-                            {task.taskName}
+                            <span
+                              className="block whitespace-nowrap text-[9px] origin-bottom-left"
+                              style={{
+                                transform: 'rotate(-55deg)',
+                                transformOrigin: 'center center',
+                                maxWidth: 75,
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                              }}
+                            >
+                              {task.taskName}
+                            </span>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="max-w-xs">
+                          <p className="font-medium">{task.taskName}</p>
+                          <p className="text-xs text-muted-foreground capitalize">{task.category}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+
+              <tbody>
+                {sortedModels.map((model) => {
+                  const providerColor = PROVIDER_COLORS[model.provider.toLowerCase()] || '#888'
+                  return (
+                    <tr key={model.model} className="hover:bg-muted/20">
+                      <td className="sticky left-0 z-10 bg-background border-b border-r border-border px-2 py-1.5 whitespace-nowrap">
+                        <div className="flex items-center gap-1.5">
+                          <span
+                            className="inline-block w-2 h-2 rounded-full flex-shrink-0"
+                            style={{ backgroundColor: providerColor }}
+                          />
+                          <span className="font-medium text-foreground truncate max-w-[160px]" title={model.model}>
+                            {model.model}
                           </span>
                         </div>
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="max-w-xs">
-                        <p className="font-medium">{task.taskName}</p>
-                        <p className="text-xs text-muted-foreground capitalize">{task.category}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </th>
-                ))}
-              </tr>
-            </thead>
+                      </td>
+                      {allTasks.map((task) => {
+                        const taskData = model.tasks.get(task.taskId)
+                        const ratio = taskData ? taskData.score / taskData.maxScore : 0
+                        const hasData = !!taskData
+                        const isHovered = hoveredCell?.model === model.model && hoveredCell?.taskId === task.taskId
 
-            <tbody>
-              {sortedModels.map((model) => {
-                const providerColor = PROVIDER_COLORS[model.provider.toLowerCase()] || '#888'
-                return (
-                  <tr key={model.model} className="hover:bg-muted/20">
-                    <td className="sticky left-0 z-10 bg-background border-b border-r border-border px-2 py-1.5 whitespace-nowrap">
-                      <div className="flex items-center gap-1.5">
-                        <span
-                          className="inline-block w-2 h-2 rounded-full flex-shrink-0"
-                          style={{ backgroundColor: providerColor }}
-                        />
-                        <span className="font-medium text-foreground truncate max-w-[160px]" title={model.model}>
-                          {model.model}
-                        </span>
-                      </div>
-                    </td>
-                    {allTasks.map((task) => {
-                      const taskData = model.tasks.get(task.taskId)
-                      const ratio = taskData ? taskData.score / taskData.maxScore : 0
-                      const hasData = !!taskData
-                      const isHovered = hoveredCell?.model === model.model && hoveredCell?.taskId === task.taskId
+                        return (
+                          <td
+                            key={task.taskId}
+                            className="border-b border-border/30 p-0 text-center relative"
+                            style={{
+                              backgroundColor: hasData ? getScoreColor(ratio) : 'transparent',
+                              width: 36,
+                              minWidth: 36,
+                              maxWidth: 36,
+                            }}
+                            onMouseEnter={() => setHoveredCell({ model: model.model, taskId: task.taskId })}
+                            onMouseLeave={() => setHoveredCell(null)}
+                          >
+                            {hasData && (
+                              <span
+                                className="text-[10px] font-medium"
+                                style={{ color: getScoreTextColor(ratio) }}
+                              >
+                                {Math.round(ratio * 100)}
+                              </span>
+                            )}
+                            {!hasData && (
+                              <span className="text-muted-foreground/30 text-[10px]">-</span>
+                            )}
 
-                      return (
-                        <td
-                          key={task.taskId}
-                          className="border-b border-border/30 p-0 text-center relative"
-                          style={{
-                            backgroundColor: hasData ? getScoreColor(ratio) : 'transparent',
-                            width: 36,
-                            minWidth: 36,
-                            maxWidth: 36,
-                          }}
-                          onMouseEnter={() => setHoveredCell({ model: model.model, taskId: task.taskId })}
-                          onMouseLeave={() => setHoveredCell(null)}
-                        >
-                          {hasData && (
-                            <span
-                              className="text-[10px] font-medium"
-                              style={{ color: getScoreTextColor(ratio) }}
-                            >
-                              {Math.round(ratio * 100)}
-                            </span>
-                          )}
-                          {!hasData && (
-                            <span className="text-muted-foreground/30 text-[10px]">-</span>
-                          )}
-
-                          {/* Tooltip */}
-                          {isHovered && taskData && (
-                            <div className="absolute z-30 bottom-full left-1/2 -translate-x-1/2 mb-1 pointer-events-none">
-                              <div className="rounded-lg border border-border bg-popover px-3 py-2 shadow-md whitespace-nowrap">
-                                <p className="font-medium text-sm text-popover-foreground">{model.model}</p>
-                                <p className="text-xs text-muted-foreground">{task.taskName}</p>
-                                <p className="text-xs mt-1">
-                                  <span className="text-muted-foreground">Score: </span>
-                                  <span className="font-medium">{taskData.score}/{taskData.maxScore}</span>
-                                  <span className="text-muted-foreground ml-1">({Math.round(ratio * 100)}%)</span>
-                                </p>
+                            {/* Tooltip */}
+                            {isHovered && taskData && (
+                              <div className="absolute z-30 bottom-full left-1/2 -translate-x-1/2 mb-1 pointer-events-none">
+                                <div className="rounded-lg border border-border bg-popover px-3 py-2 shadow-md whitespace-nowrap">
+                                  <p className="font-medium text-sm text-popover-foreground">{model.model}</p>
+                                  <p className="text-xs text-muted-foreground">{task.taskName}</p>
+                                  <p className="text-xs mt-1">
+                                    <span className="text-muted-foreground">Score: </span>
+                                    <span className="font-medium">{taskData.score}/{taskData.maxScore}</span>
+                                    <span className="text-muted-foreground ml-1">({Math.round(ratio * 100)}%)</span>
+                                  </p>
+                                </div>
                               </div>
-                            </div>
-                          )}
-                        </td>
-                      )
-                    })}
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+                            )}
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
           </div>
         </ShareableWrapper>
       </TooltipProvider>

--- a/lib/task-metadata.ts
+++ b/lib/task-metadata.ts
@@ -1,3 +1,10 @@
+export const IMAGE_GEN_TASK_ID = "task_13_image_gen";
+export const EXCLUDED_LEADERBOARD_TASK_IDS = new Set<string>([IMAGE_GEN_TASK_ID]);
+
+export function isExcludedLeaderboardTask(taskId: string): boolean {
+  return EXCLUDED_LEADERBOARD_TASK_IDS.has(taskId);
+}
+
 export const TASK_FALLBACK: Record<string, { name: string; category: string }> =
   {
     task_00_sanity: { name: "Sanity Check", category: "validation" },

--- a/lib/transforms.ts
+++ b/lib/transforms.ts
@@ -8,7 +8,7 @@ import type {
 } from "@/lib/types";
 import { TASK_FALLBACK } from "@/lib/task-metadata";
 
-const EPSILON = 1e-6;
+export const EPSILON = 1e-6;
 
 /**
  * Normalize provider name. When the provider is "openrouter", the real
@@ -28,11 +28,11 @@ export const normalizeProvider = (provider: string, model?: string): string => {
 
 /**
  * Estimate the number of successful tasks from a score percentage.
- * Uses best_score_percentage * max_score (from API) — but since max_score
- * is not in ApiLeaderboardEntry, we approximate using a standard task count of 40
- * (the current PinchBench task count). Falls back to null if score is unavailable.
+ * Since max_score is not present on ApiLeaderboardEntry, this uses an approximate
+ * task count. Callers with submission-level data should pass an exact remaining
+ * task count instead of relying on the default.
  */
-function estimateSuccessfulTasks(
+export function estimateSuccessfulTasks(
   scorePercentage: number | null | undefined,
   taskCount = 40,
 ): number | null {


### PR DESCRIPTION
## Summary

Adds an `excludeImageGen` leaderboard mode that removes image-generation tasks from score calculations and related views.

This is implemented dynamically from submission data rather than hardcoding task counts, so it stays correct if tasks are added later or if more excluded tasks are introduced.

## What changed

### Leaderboard filtering
- add `excludeImageGen` query-param support on the main leaderboard page
- recalculate filtered leaderboard scores from actual submission task data
- recompute derived metrics (including CPST) from the remaining tasks only
- preserve entries if submission detail fetches fail instead of silently dropping models

### Shared task exclusion logic
- add centralized exclusion helpers in `lib/task-metadata.ts`
- make exclusion logic reusable across leaderboard, submission, and heatmap views

### UI updates
- add “Exclude image generation tasks” toggle to leaderboard controls
- pass filtered state through leaderboard view
- make task heatmap honor the exclusion mode
- make submission detail pages honor the exclusion mode

### Fixes included
- fix parser/markup issues in `components/task-heatmap.tsx`
- fix runtime issues from missing task-exclusion imports
- avoid hardcoded filtered task counts

## Files changed

- `app/page.tsx`
- `app/submission/[id]/page.tsx`
- `components/leaderboard-header.tsx`
- `components/leaderboard-view.tsx`
- `components/task-breakdown.tsx`
- `components/task-heatmap.tsx`
- `lib/task-metadata.ts`
- `lib/transforms.ts`

## Validation

### Build
- `npm run build` ✅

### Route smoke tests
- `/` ✅
- `/?excludeImageGen=true` ✅
- `/about` ✅
- `/runs` ✅
- `/claim` ✅
- `/claim/success` ✅
- `/claim/error` ✅
- `/user/test` ✅
- `/submission/5d73c775-fb81-4df1-ac2f-a08434541601` ✅
- `/submission/5d73c775-fb81-4df1-ac2f-a08434541601?excludeImageGen=true` ✅
- invalid route returns 404 ✅

### Browser checks
- unfiltered home loads ✅
- filtered home loads ✅
- filtered submission page loads ✅
- runs page loads ✅
- no browser console/page errors observed ✅
