### PR TITLE
feat: add model landing pages with search and score trend

### DIFF
--- a/app/model/[...slug]/page.tsx
+++ b/app/model/[...slug]/page.tsx
@@ -1,0 +1,196 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { ArrowLeft, BarChart3, Clock, DollarSign, Activity } from 'lucide-react'
+import { PROVIDER_COLORS } from '@/lib/types'
+import { fetchModelSubmissions } from '@/lib/api'
+import { formatDistanceToNow } from 'date-fns'
+import { ModelScoreTrend } from '@/components/model-score-trend'
+
+interface ModelPageProps {
+  params: Promise<{ slug: string[] }>
+  searchParams: Promise<{ official?: string }>
+}
+
+export default async function ModelPage({ params, searchParams }: ModelPageProps) {
+  const { slug } = await params
+  const { official } = await searchParams
+  const officialOnly = official !== 'false'
+
+  if (slug.length < 2) {
+    notFound()
+  }
+
+  const provider = slug[0]
+  const modelName = slug.slice(1).join('/')
+
+  let data
+  try {
+    data = await fetchModelSubmissions(modelName, { officialOnly })
+  } catch (error) {
+    return (
+      <div className="min-h-screen bg-background p-6">
+        <Card className="max-w-4xl mx-auto p-6">
+          <h2 className="text-xl font-bold mb-4">Error loading model data</h2>
+          <p className="text-muted-foreground">Could not fetch submissions for {modelName}.</p>
+          <Link href="/">
+             <Button className="mt-4">Back to Leaderboard</Button>
+          </Link>
+        </Card>
+      </div>
+    )
+  }
+
+  if (!data || data.submissions.length === 0) {
+    notFound()
+  }
+
+  const submissions = data.submissions.sort((a, b) => 
+    new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  )
+
+  const scores = submissions.map(s => s.score_percentage * 100)
+  const bestScore = Math.max(...scores)
+  const avgScore = scores.reduce((a, b) => a + b, 0) / scores.length
+  const sortedScores = [...scores].sort((a, b) => a - b)
+  const medianScore = sortedScores[Math.floor(sortedScores.length / 2)]
+
+  const avgCost = submissions.reduce((a, b) => a + (b.total_cost_usd || 0), 0) / submissions.length
+  const avgSpeed = submissions.reduce((a, b) => a + (b.total_execution_time_seconds || 0), 0) / submissions.length
+
+  const compareUrl = `/?view=graphs&graph=radar&models=${encodeURIComponent(modelName)}${officialOnly ? '' : '&official=false'}`
+
+  const trendData = submissions.map(s => ({
+    timestamp: s.timestamp,
+    score: s.score_percentage * 100
+  }))
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b border-border bg-card/50">
+        <div className="max-w-7xl mx-auto px-6 py-8">
+          <Link
+            href={officialOnly ? '/' : '/?official=false'}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors mb-4 inline-block"
+          >
+            <Button variant="ghost" size="sm" className="-ml-2">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Leaderboard
+            </Button>
+          </Link>
+          <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-3 mb-2">
+                <code className="text-3xl font-mono font-bold text-foreground">
+                  {modelName}
+                </code>
+                <Badge
+                  variant="outline"
+                  className="text-sm"
+                  style={{
+                    borderColor: PROVIDER_COLORS[provider as keyof typeof PROVIDER_COLORS] || 'hsl(var(--border))',
+                    color: PROVIDER_COLORS[provider as keyof typeof PROVIDER_COLORS] || 'hsl(var(--foreground))',
+                    backgroundColor: `${PROVIDER_COLORS[provider as keyof typeof PROVIDER_COLORS]}10` || 'transparent'
+                  }}
+                >
+                  {provider}
+                </Badge>
+              </div>
+              <p className="text-muted-foreground">
+                Model performance overview and history
+              </p>
+            </div>
+            <Link href={compareUrl}>
+              <Button className="bg-primary text-primary-foreground">
+                <Activity className="h-4 w-4 mr-2" />
+                Compare with other models
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-6 py-8 space-y-8">
+        {/* Stats Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+          <Card className="p-4 flex flex-col items-center justify-center text-center">
+            <BarChart3 className="h-5 w-5 text-primary mb-2" />
+            <span className="text-sm text-muted-foreground">Best Score</span>
+            <span className="text-2xl font-bold">{bestScore.toFixed(1)}%</span>
+          </Card>
+          <Card className="p-4 flex flex-col items-center justify-center text-center">
+            <Activity className="h-5 w-5 text-blue-500 mb-2" />
+            <span className="text-sm text-muted-foreground">Average Score</span>
+            <span className="text-2xl font-bold">{avgScore.toFixed(1)}%</span>
+          </Card>
+          <Card className="p-4 flex flex-col items-center justify-center text-center">
+            <Activity className="h-5 w-5 text-purple-500 mb-2" />
+            <span className="text-sm text-muted-foreground">Median Score</span>
+            <span className="text-2xl font-bold">{medianScore.toFixed(1)}%</span>
+          </Card>
+          <Card className="p-4 flex flex-col items-center justify-center text-center">
+            <DollarSign className="h-5 w-5 text-green-500 mb-2" />
+            <span className="text-sm text-muted-foreground">Avg Cost</span>
+            <span className="text-2xl font-bold">${avgCost.toFixed(4)}</span>
+          </Card>
+          <Card className="p-4 flex flex-col items-center justify-center text-center">
+            <Clock className="h-5 w-5 text-orange-500 mb-2" />
+            <span className="text-sm text-muted-foreground">Avg Speed</span>
+            <span className="text-2xl font-bold">{avgSpeed.toFixed(1)}s</span>
+          </Card>
+        </div>
+
+        {/* Score Trend Chart */}
+        <Card className="p-6">
+          <h3 className="text-lg font-semibold mb-4">Score Trend Over Time</h3>
+          <ModelScoreTrend data={trendData} />
+        </Card>
+
+        {/* Submissions Table */}
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">Submission History</h3>
+          <div className="rounded-md border border-border overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 border-b border-border">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">Date</th>
+                  <th className="px-4 py-3 text-right font-medium text-muted-foreground">Score</th>
+                  <th className="px-4 py-3 text-right font-medium text-muted-foreground">Speed</th>
+                  <th className="px-4 py-3 text-right font-medium text-muted-foreground">Cost</th>
+                  <th className="px-4 py-3 text-right font-medium text-muted-foreground">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {submissions.map((s) => (
+                  <tr key={s.id} className="hover:bg-muted/30 transition-colors">
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {formatDistanceToNow(new Date(s.timestamp), { addSuffix: true })}
+                    </td>
+                    <td className="px-4 py-3 text-right font-medium">
+                      {(s.score_percentage * 100).toFixed(1)}%
+                    </td>
+                    <td className="px-4 py-3 text-right text-muted-foreground">
+                      {s.total_execution_time_seconds ? `${s.total_execution_time_seconds.toFixed(1)}s` : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-right text-muted-foreground">
+                      {s.total_cost_usd ? `$${s.total_cost_usd.toFixed(4)}` : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <Link href={`/submission/${s.id}${officialOnly ? '' : '?official=false'}`}>
+                        <Button variant="outline" size="sm">
+                          View Details
+                        </Button>
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/components/leaderboard-header.tsx
+++ b/components/leaderboard-header.tsx
@@ -1,13 +1,15 @@
 'use client'
 
 import Link from 'next/link'
-import type { BenchmarkVersion } from '@/lib/types'
+import type { BenchmarkVersion, LeaderboardEntry } from '@/lib/types'
 import { VersionSelector } from '@/components/version-selector'
+import { ModelSearch } from '@/components/model-search'
 
 type ViewMode = 'success' | 'speed' | 'cost' | 'value' | 'graphs'
 type ScoreMode = 'best' | 'average'
 
 interface LeaderboardHeaderProps {
+    entries: LeaderboardEntry[]
     filteredEntryCount: number
     totalRuns: number
     versions: BenchmarkVersion[]
@@ -19,14 +21,17 @@ interface LeaderboardHeaderProps {
     scoreMode: ScoreMode
     officialOnly: boolean
     openWeightsOnly: boolean
+    modelSearchValue: string
     onViewChange: (view: ViewMode) => void
     onScoreModeChange: (mode: ScoreMode) => void
     onOfficialOnlyChange: (officialOnly: boolean) => void
     onOpenWeightsOnlyChange: (openWeightsOnly: boolean) => void
     onClearProviderFilter: () => void
+    onModelSearchChange: (value: string) => void
 }
 
 export function LeaderboardHeader({
+    entries,
     filteredEntryCount,
     totalRuns,
     versions,
@@ -38,17 +43,19 @@ export function LeaderboardHeader({
     scoreMode,
     officialOnly,
     openWeightsOnly,
+    modelSearchValue,
     onViewChange,
     onScoreModeChange,
     onOfficialOnlyChange,
     onOpenWeightsOnlyChange,
     onClearProviderFilter,
+    onModelSearchChange,
 }: LeaderboardHeaderProps) {
     return (
         <header className="border-b border-border">
             <div className="max-w-7xl mx-auto px-4 py-4 md:px-6 md:py-6">
-                <div className="flex items-center justify-between">
-                    <div className="flex flex-col items-center gap-2">
+                <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+                    <div className="flex flex-col items-start gap-2">
                         <div className="flex items-center gap-3">
                             <img src="/apple-touch-icon.png" alt="PinchBench - OpenClaw Benchmark" className="w-8 h-8 md:w-10 md:h-10" />
                             <div>
@@ -58,17 +65,17 @@ export function LeaderboardHeader({
                                 <p className="hidden md:block text-sm text-muted-foreground">Find the best model for your OpenClaw</p>
                             </div>
                         </div>
-                        <div className="flex justify-end mb-4 md:inline-block hidden">
-                            <a
-                                href="https://github.com/pinchbench/skill"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-                            >
-                                <span>Run the benchmark yourself →</span>
-                            </a>
-                        </div>
                     </div>
+
+                    <div className="flex-1 flex justify-center max-w-sm w-full">
+                        <ModelSearch
+                            entries={entries}
+                            officialOnly={officialOnly}
+                            searchValue={modelSearchValue}
+                            onSearchChange={onModelSearchChange}
+                        />
+                    </div>
+
                     <div className="flex flex-col items-end gap-3">
                         <div className="flex items-center gap-3">
                             <Link

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -126,9 +126,11 @@ export function LeaderboardTable({ entries }: LeaderboardTableProps) {
                   </div>
                 </td>
                 <td className="px-4 py-4">
-                  <code className="text-sm font-mono text-foreground">
-                    {entry.model}
-                  </code>
+                  <Link href={`/model/${entry.provider.toLowerCase()}/${entry.model}${entry.official === false ? '?official=false' : ''}`}>
+                    <code className="text-sm font-mono text-foreground hover:text-primary transition-colors cursor-pointer">
+                      {entry.model}
+                    </code>
+                  </Link>
                 </td>
                 <td className="px-4 py-4">
                   <Badge
@@ -200,7 +202,7 @@ export function LeaderboardTable({ entries }: LeaderboardTableProps) {
         {displayedEntries.map((entry) => (
           <Link
             key={entry.submission_id}
-            href={`/submission/${entry.submission_id}`}
+            href={`/model/${entry.provider.toLowerCase()}/${entry.model}${entry.official === false ? '?official=false' : ''}`}
             className="block p-4 hover:bg-muted/30 transition-colors"
           >
             <div className="flex items-start justify-between mb-3">

--- a/components/leaderboard-view.tsx
+++ b/components/leaderboard-view.tsx
@@ -45,6 +45,7 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
     const initialGraphTab = VALID_GRAPH_TABS.includes(searchParams.get('graph') as GraphSubTab)
         ? (searchParams.get('graph') as GraphSubTab)
         : 'scatter'
+    const initialModelSearch = searchParams.get('model') || ''
 
     const [view, setViewState] = useState<ViewMode>(initialView)
     const [officialOnlyState, setOfficialOnlyState] = useState<boolean>(officialOnly)
@@ -52,6 +53,7 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
     const [providerFilter, setProviderFilterState] = useState<string | null>(initialProvider)
     const [openWeightsOnly, setOpenWeightsOnlyState] = useState<boolean>(initialOpenWeights)
     const [graphSubTab, setGraphSubTabState] = useState<GraphSubTab>(initialGraphTab)
+    const [modelSearch, setModelSearchState] = useState<string>(initialModelSearch)
 
     // Helper to update URL params without full page reload
     const updateUrl = useCallback((updates: Record<string, string | null>) => {
@@ -95,35 +97,35 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
         updateUrl({ graph: t === 'scatter' ? null : t })
     }, [updateUrl])
 
+    const handleModelSearchChange = useCallback((s: string) => {
+        setModelSearchState(s)
+        updateUrl({ model: s || null })
+    }, [updateUrl])
+
     const setOfficialOnly = useCallback((v: boolean) => {
         setOfficialOnlyState(v)
         updateUrl({ official: v ? null : 'false' })
     }, [updateUrl])
 
     const filteredEntries = useMemo(() => {
-        let result = entries
-        if (providerFilter) {
-            result = result.filter(
-                (entry) => entry.provider.toLowerCase() === providerFilter.toLowerCase()
-            )
-        }
-        if (openWeightsOnly) {
-            result = result.filter((entry) => entry.weights === 'Open')
-        }
-        return result
-    }, [entries, providerFilter, openWeightsOnly])
+        return entries.filter(entry => {
+            if (providerFilter && entry.provider.toLowerCase() !== providerFilter.toLowerCase()) return false
+            if (openWeightsOnly && entry.weights !== 'Open') return false
+            if (modelSearch && !entry.model.toLowerCase().includes(modelSearch.toLowerCase())) return false
+            return true
+        })
+    }, [entries, providerFilter, openWeightsOnly, modelSearch])
 
     const providerColor = providerFilter
         ? PROVIDER_COLORS[providerFilter.toLowerCase()] || '#666'
         : undefined
 
-    const totalRuns = useMemo(() => {
-        return filteredEntries.reduce((sum, entry) => sum + (entry.submission_count ?? 0), 0)
-    }, [filteredEntries])
+    const totalRuns = entries.reduce((acc, entry) => acc + (entry.submission_count || 1), 0)
 
     return (
         <div className="min-h-screen bg-background">
             <LeaderboardHeader
+                entries={entries}
                 filteredEntryCount={filteredEntries.length}
                 totalRuns={totalRuns}
                 versions={versions}
@@ -140,6 +142,8 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                 onOfficialOnlyChange={setOfficialOnly}
                 onOpenWeightsOnlyChange={setOpenWeightsOnly}
                 onClearProviderFilter={() => setProviderFilter(null)}
+                onModelSearchChange={handleModelSearchChange}
+                modelSearchValue={modelSearch}
             />
 
             <main className="max-w-7xl mx-auto px-6 py-8">

--- a/components/model-score-trend.tsx
+++ b/components/model-score-trend.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+import { Card } from '@/components/ui/card'
+
+interface ScoreData {
+  timestamp: string
+  score: number
+}
+
+interface ModelScoreTrendProps {
+  data: ScoreData[]
+}
+
+export function ModelScoreTrend({ data }: ModelScoreTrendProps) {
+  const chartData = data
+    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+    .map((d) => ({
+      date: new Date(d.timestamp).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      }),
+      score: Number(d.score.toFixed(1)),
+      fullDate: new Date(d.timestamp).toLocaleString(),
+    }))
+
+  return (
+    <div className="h-[350px] w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={chartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+          <XAxis 
+            dataKey="date" 
+            axisLine={false}
+            tickLine={false}
+            tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+            dy={10}
+          />
+          <YAxis 
+            domain={[0, 100]} 
+            axisLine={false}
+            tickLine={false}
+            tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+            tickFormatter={(val) => `${val}%`}
+          />
+          <Tooltip 
+            contentStyle={{ 
+              backgroundColor: 'hsl(var(--background))', 
+              borderColor: 'hsl(var(--border))',
+              borderRadius: '8px'
+            }}
+            labelStyle={{ color: 'hsl(var(--muted-foreground))', fontSize: '12px', marginBottom: '4px' }}
+            itemStyle={{ fontSize: '14px', fontWeight: 'bold' }}
+            formatter={(value: number) => [`${value}%`, 'Score']}
+            labelFormatter={(label, payload) => payload[0]?.payload.fullDate || label}
+          />
+          <Line 
+            type="monotone" 
+            dataKey="score" 
+            stroke="hsl(var(--primary))" 
+            strokeWidth={3} 
+            dot={{ r: 4, fill: 'hsl(var(--primary))', strokeWidth: 0 }}
+            activeDot={{ r: 6, stroke: 'hsl(var(--background))', strokeWidth: 2 }}
+            animationDuration={1000}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/components/model-search.tsx
+++ b/components/model-search.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import * as React from 'react'
+import { Search } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+} from '@/components/ui/popover'
+import * as PopoverPrimitive from '@radix-ui/react-popover'
+import type { LeaderboardEntry } from '@/lib/types'
+
+interface ModelSearchProps {
+  entries: LeaderboardEntry[]
+  officialOnly: boolean
+  searchValue?: string
+  onSearchChange?: (value: string) => void
+}
+
+export function ModelSearch({ entries, officialOnly, searchValue, onSearchChange }: ModelSearchProps) {
+  const [open, setOpen] = React.useState(false)
+  const router = useRouter()
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  const uniqueModels = React.useMemo(() => {
+    const models = new Map<string, { model: string; provider: string }>()
+    entries.forEach((e) => {
+      if (!models.has(e.model)) {
+        models.set(e.model, { model: e.model, provider: e.provider })
+      }
+    })
+    return Array.from(models.values())
+  }, [entries])
+
+  return (
+    <div className="relative w-full max-w-sm">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverPrimitive.Anchor asChild>
+          <div className="relative w-full">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder="Search or filter models..."
+              value={searchValue}
+              onChange={(e) => {
+                onSearchChange?.(e.target.value)
+                if (!open) setOpen(true)
+              }}
+              onFocus={() => {
+                if (uniqueModels.length > 0) setOpen(true)
+              }}
+              className="w-full bg-muted/50 border border-border rounded-md pl-9 pr-4 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+        </PopoverPrimitive.Anchor>
+        <PopoverContent
+          className="w-[var(--radix-popover-trigger-width)] p-0"
+          align="start"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onInteractOutside={(e) => {
+            // Don't close if we're clicking the input
+            if (e.target === inputRef.current) {
+              e.preventDefault()
+            }
+          }}
+        >
+          <Command loop>
+            <CommandList>
+              <CommandEmpty>No model found.</CommandEmpty>
+              <CommandGroup heading="Models">
+                {uniqueModels
+                  .filter(m =>
+                    !searchValue ||
+                    m.model.toLowerCase().includes(searchValue.toLowerCase()) ||
+                    m.provider.toLowerCase().includes(searchValue.toLowerCase())
+                  )
+                  .map((m) => (
+                    <CommandItem
+                      key={m.model}
+                      value={m.model}
+                      onSelect={() => {
+                        router.push(`/model/${m.provider.toLowerCase()}/${m.model}${officialOnly ? '' : '?official=false'}`)
+                        setOpen(false)
+                      }}
+                    >
+                      <div className="flex flex-col">
+                        <span className="font-mono text-sm">{m.model}</span>
+                        <span className="text-xs text-muted-foreground">{m.provider}</span>
+                      </div>
+                    </CommandItem>
+                  ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/components/simple-leaderboard.tsx
+++ b/components/simple-leaderboard.tsx
@@ -216,6 +216,9 @@ export function SimpleLeaderboard({
   const hiddenRowCount = hiddenEntries.length + nullEntries.length
   const showToggle = hiddenRowCount > 0
 
+  const modelHref = (provider: string, model: string) =>
+    `/model/${provider.toLowerCase()}/${model}${officialOnly ? '' : '?official=false'}`
+
   // ----------------------------------------------------------------
   // VALUE view
   // ----------------------------------------------------------------
@@ -321,8 +324,8 @@ export function SimpleLeaderboard({
                         <span className="text-sm font-medium text-muted-foreground">{index + 1}</span>
                       </td>
                       <td className="px-2 md:px-4 py-3">
-                        <Link href={`/submission/${entry.submission_id}`} className="flex items-center gap-2 transition-colors">
-                          <code className="text-xs md:text-sm font-mono truncate max-w-[150px] md:max-w-none">{entry.model}</code>
+                        <Link href={modelHref(entry.provider, entry.model)} className="flex items-center gap-2 transition-colors">
+                          <code className="text-xs md:text-sm font-mono truncate max-w-[150px] md:max-w-none hover:text-primary transition-colors cursor-pointer">{entry.model}</code>
                         </Link>
                       </td>
                       <td className="hidden md:table-cell px-4 py-3">
@@ -366,8 +369,8 @@ export function SimpleLeaderboard({
                   <tr key={entry.submission_id} className="text-muted-foreground opacity-60">
                     <td className="px-2 md:px-4 py-3">--</td>
                     <td className="px-2 md:px-4 py-3">
-                      <Link href={`/submission/${entry.submission_id}`}>
-                        <code className="text-xs md:text-sm font-mono truncate max-w-[150px] md:max-w-none">{entry.model}</code>
+                      <Link href={modelHref(entry.provider, entry.model)}>
+                        <code className="text-xs md:text-sm font-mono truncate max-w-[150px] md:max-w-none hover:text-primary transition-colors cursor-pointer">{entry.model}</code>
                       </Link>
                     </td>
                     <td className="hidden md:table-cell px-4 py-3">
@@ -552,7 +555,7 @@ export function SimpleLeaderboard({
                   <Tooltip key={entry.submission_id}>
                     <TooltipTrigger asChild>
                       <Link
-                        href={submissionHref(entry.submission_id)}
+                        href={modelHref(entry.provider, entry.model)}
                         className="block group"
                       >
                         <div className="flex items-center gap-3">
@@ -743,7 +746,7 @@ export function SimpleLeaderboard({
                     >
                       <td className="px-2 md:px-4 py-3">
                         <Link
-                          href={submissionHref(entry.submission_id)}
+                          href={modelHref(entry.provider, entry.model)}
                           className="flex items-center gap-2 transition-colors"
                         >
                           <span className="text-lg">{getCrabEmoji(entry.rank)}</span>
@@ -935,7 +938,7 @@ export function SimpleLeaderboard({
                   </td>
                   <td className="px-2 md:px-4 py-3">
                     <Link
-                      href={submissionHref(entry.submission_id)}
+                      href={modelHref(entry.provider, entry.model)}
                       className="flex items-center gap-2 transition-colors"
                     >
                       <code className="text-xs md:text-sm font-mono truncate max-w-[150px] md:max-w-none">{entry.model}</code>
@@ -952,7 +955,8 @@ export function SimpleLeaderboard({
                       onClick={() => onProviderClick?.(entry.provider)}
                       className="text-xs font-medium hover:underline cursor-pointer"
                       style={{
-                        color: PROVIDER_COLORS[entry.provider.toLowerCase()] || '#666',
+                        color:
+                          PROVIDER_COLORS[entry.provider.toLowerCase()] || '#666',
                       }}
                     >
                       {entry.provider}
@@ -966,11 +970,11 @@ export function SimpleLeaderboard({
                 </tr>
               ))}
               {showAllEntries && nullEntries.map((entry) => (
-                <tr key={entry.submission_id} className="text-muted-foreground">
+                <tr key={entry.submission_id} className="text-muted-foreground opacity-60">
                   <td className="px-2 md:px-4 py-3">--</td>
                   <td className="px-2 md:px-4 py-3">
                     <Link
-                      href={submissionHref(entry.submission_id)}
+                      href={modelHref(entry.provider, entry.model)}
                       className="flex items-center gap-2 transition-colors"
                     >
                       <code className="text-xs md:text-sm font-mono truncate max-w-[150px] md:max-w-none">{entry.model}</code>
@@ -987,7 +991,8 @@ export function SimpleLeaderboard({
                       onClick={() => onProviderClick?.(entry.provider)}
                       className="text-xs font-medium hover:underline cursor-pointer"
                       style={{
-                        color: PROVIDER_COLORS[entry.provider.toLowerCase()] || '#666',
+                        color:
+                          PROVIDER_COLORS[entry.provider.toLowerCase()] || '#666',
                       }}
                     >
                       {entry.provider}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -81,6 +81,16 @@ export async function fetchStats(): Promise<StatsResponse> {
   return fetchJson<StatsResponse>("/stats");
 }
 
+export async function fetchModelSubmissions(
+  model: string,
+  options?: OfficialFilterOptions,
+): Promise<ModelSubmissionsResponse> {
+  const params = new URLSearchParams();
+  params.set("official", String(options?.officialOnly ?? true));
+  params.set("model", model);
+  return fetchJson<ModelSubmissionsResponse>(`/model-submissions?${params.toString()}`);
+}
+
 /**
  * Fetch a single submission detail (client-side, no ISR caching).
  * Used by chart components that need task-level data.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -202,6 +202,8 @@ export interface ApiModelSubmissionItem {
   max_score: number;
   timestamp: string;
   is_best: boolean;
+  total_cost_usd?: number | null;
+  total_execution_time_seconds?: number | null;
   official?: boolean;
 }
 


### PR DESCRIPTION
- Add `/model/[provider]/[model]` page with stats grid (best/avg/median score, cost, speed), Recharts score trend line chart, and submission history table
- Add `ModelSearch` component: Radix Popover + Command-based autocomplete dropdown for navigating to model pages from the header
- Add `ModelScoreTrend` Recharts line chart component for model score history visualization
- Integrate `ModelSearch` into `LeaderboardHeader` with new `entries` and `modelSearch` props
- Add `modelSearch` URL state param in `LeaderboardView` with combined filter logic (provider + open weights + model search)
- Update model name links in `LeaderboardTable` and `SimpleLeaderboard` to route to `/model/[provider]/[model]` instead of `/submission/[id]`
- Add `fetchModelSubmissions()` API client function hitting `/model-submissions` endpoint
- Extend `ApiModelSubmissionItem` with `total_cost_usd` and `total_execution_time_seconds` fields

  closes #35