### PR TITLE
fix: calculateRanks wrong rank for tied entries

### DIFF
--- a/lib/transforms.ts
+++ b/lib/transforms.ts
@@ -92,14 +92,19 @@ export function calculateRanks(
     return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
   });
 
+  let lastRank = 0;
+  let lastPercentage = NaN;
+
   return sorted.map((entry, index) => {
     if (
-      index > 0 &&
-      Math.abs(entry.percentage - sorted[index - 1].percentage) <= EPSILON
+      lastRank > 0 &&
+      Math.abs(entry.percentage - lastPercentage) <= EPSILON
     ) {
-      return { ...entry, rank: sorted[index - 1].rank };
+      return { ...entry, rank: lastRank };
     }
-    return { ...entry, rank: index + 1 };
+    lastRank = index + 1;
+    lastPercentage = entry.percentage;
+    return { ...entry, rank: lastRank };
   });
 }
 


### PR DESCRIPTION
BUG in lib/transforms.ts calculateRanks() (lines 95-103):

  ```
return sorted.map((entry, index) => {
    if (
      index > 0 &&
      Math.abs(entry.percentage - sorted[index - 1].percentage) <= EPSILON
    ) {
      return { ...entry, rank: sorted[index - 1].rank };
      //                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      //  BUG: sorted[index-1] was never modified by .map().
      //  It still has rank:0 (the initial value), NOT undefined.
      //  So tied entries get rank=0 instead of the correct shared rank.
    }
    return { ...entry, rank: index + 1 };
  });
```

ROOT CAUSE:
  .map() creates a NEW array; it never mutates the original sorted array.
  Therefore sorted[index-1].rank is always the initial value (0 or undefined),
  NOT the rank assigned in the previous callback iteration.

IMPACT:
  When two entries have identical percentages (tie), the second tied entry
  gets rank=sorted[0].rank=0 instead of sharing rank=1 with the first.
  Example: Model-A 85% and Model-B 85% would get ranks 1 and 0 respectively.

FIX:
  Track the previous entry's state using two scalar variables (lastRank,
  lastPercentage) instead of reading from the unmutated sorted array.
  Use index+1 for standard competition ranking (1, 1, 3, 4...) rather
  than sequential ranking (1, 1, 2, 3...).