### PR TITLE
Add best-for recommendations and comparison pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A streamlined, crab-themed benchmarking leaderboard for comparing LLM models as 
 - **Clean tabbed interface** for Success Rate, Speed, and Cost views
 - **Crab-themed rankings** - Lobster for #1, Crab for #2, Shrimp for #3
 - **Visual bar chart** showing model performance at a glance
+- **Quick Picks** recommendation cards for best overall, fastest, cheapest, best value, coding, and data-oriented models
+- **Best-for landing pages** at `/best-for/coding`, `/best-for/data-analysis`, and `/best-for/budget` with SEO-focused copy and top-5 comparisons
+- **Category champion badges** on leaderboard rows for models that lead task categories
+- **Model comparison tool** in the Graphs tab for comparing 2-3 selected models across score, cost, speed, and efficiency
 - **Simplified table** with essential metrics only
 - **Color-coded scores** (green/yellow/red) for quick assessment
 - **Provider color coding** with brand colors (Anthropic, OpenAI, Google, etc.)
@@ -24,6 +28,13 @@ A streamlined, crab-themed benchmarking leaderboard for comparing LLM models as 
 - **Grading type badges** (Automated, LLM Judge, Hybrid)
 - **Status indicators** for success, warnings, and timeouts
 - **Metadata display** including OpenClaw version and submission timestamp
+
+### Recommendations Data Flow
+
+- `/` fetches the leaderboard plus best-submission details for the top candidates, then derives category scores client-safe on the server with `lib/recommendations.ts`.
+- Quick Picks use existing leaderboard fields for overall, speed, cost, and value, and task-level submission scores for coding and data recommendations.
+- `/best-for/[slug]` reuses the same recommendation helpers so SEO landing pages and homepage badges stay consistent.
+- The current API supports this without a new endpoint. A future backend optimization could expose category aggregates directly on `/leaderboard` to avoid fetching submission details separately.
 
 ### Design Features
 
@@ -50,16 +61,19 @@ A streamlined, crab-themed benchmarking leaderboard for comparing LLM models as 
 ```
 ├── app/
 │   ├── page.tsx                    # Main leaderboard page
+│   ├── best-for/[slug]/page.tsx     # Use-case recommendation landing pages
 │   ├── submission/[id]/page.tsx    # Submission detail page
 │   ├── layout.tsx                  # Root layout
 │   └── globals.css                 # Global styles & theme
 ├── components/
-│   ├── leaderboard-table.tsx       # Main table component
+│   ├── simple-leaderboard.tsx      # Main table and bar chart component
+│   ├── quick-picks.tsx             # Recommendation cards
 │   ├── task-breakdown.tsx          # Expandable task list
 │   ├── score-gauge.tsx             # Circular score visualization
 │   └── ui/                         # shadcn/ui components
 ├── lib/
 │   ├── types.ts                    # TypeScript interfaces
+│   ├── recommendations.ts          # Best-for scoring and category badge helpers
 │   ├── mock-data.ts                # Sample benchmark data
 │   └── utils.ts                    # Utility functions
 ```

--- a/app/best-for/[slug]/page.tsx
+++ b/app/best-for/[slug]/page.tsx
@@ -1,0 +1,185 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { fetchBenchmarkVersions, fetchLeaderboard, fetchTransformedBestSubmissions } from "@/lib/api";
+import { calculateRanks, transformLeaderboardEntry } from "@/lib/transforms";
+import {
+  BEST_FOR_CATEGORIES,
+  formatCost,
+  formatDuration,
+  getBestForConfig,
+  getCategoryScore,
+  getQuickRecommendations,
+  enrichEntriesWithSubmissions,
+  sortEntriesForBestFor,
+} from "@/lib/recommendations";
+import { VersionSelector } from "@/components/version-selector";
+import { QuickPicks } from "@/components/quick-picks";
+
+interface BestForPageProps {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ version?: string; official?: string }>;
+}
+
+export function generateStaticParams() {
+  return BEST_FOR_CATEGORIES.map((config) => ({ slug: config.slug }));
+}
+
+export async function generateMetadata({ params }: BestForPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const config = getBestForConfig(slug);
+  if (!config) return {};
+
+  return {
+    title: `${config.title} | PinchBench`,
+    description: config.description,
+    openGraph: {
+      title: `${config.title} | PinchBench`,
+      description: config.description,
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${config.title} | PinchBench`,
+      description: config.description,
+    },
+  };
+}
+
+export default async function BestForPage({ params, searchParams }: BestForPageProps) {
+  const { slug } = await params;
+  const { version, official } = await searchParams;
+  const config = getBestForConfig(slug);
+  if (!config) notFound();
+
+  const officialOnly = official !== "false";
+  const [leaderboardResponse, versionsResponse] = await Promise.all([
+    fetchLeaderboard(version, { officialOnly }),
+    fetchBenchmarkVersions(),
+  ]);
+
+  const entries = calculateRanks(leaderboardResponse.leaderboard.map(transformLeaderboardEntry));
+  const submissions = await fetchTransformedBestSubmissions(entries.slice(0, 60).map((entry) => entry.submission_id));
+  const enrichedEntries = enrichEntriesWithSubmissions(entries, submissions);
+  const rankedEntries = sortEntriesForBestFor(enrichedEntries, config.slug).slice(0, 10);
+  const comparisonEntries = rankedEntries.slice(0, 5);
+  const quickPicks = getQuickRecommendations(enrichedEntries);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b border-border bg-card/40">
+        <div className="mx-auto max-w-7xl px-6 py-8">
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+            <Link href={officialOnly ? "/" : "/?official=false"} className="text-sm text-muted-foreground hover:text-foreground">
+              Back to leaderboard
+            </Link>
+            <VersionSelector versions={versionsResponse.versions} currentVersion={version ?? null} />
+          </div>
+          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.22em] text-primary">Best For</p>
+          <h1 className="max-w-3xl text-3xl font-bold tracking-tight text-foreground md:text-5xl">{config.title}</h1>
+          <p className="mt-4 max-w-3xl text-base leading-relaxed text-muted-foreground md:text-lg">{config.description}</p>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl space-y-8 px-6 py-8">
+        <QuickPicks picks={quickPicks} />
+
+        <section className="grid gap-4 md:grid-cols-3">
+          {rankedEntries.slice(0, 3).map((entry, index) => {
+            const categoryScore = config.category ? getCategoryScore(entry, config.category) : null;
+            const metric = config.slug === "budget"
+              ? `${entry.value_score?.toFixed(1) ?? "N/A"} value`
+              : `${categoryScore?.scorePercentage.toFixed(1) ?? entry.percentage.toFixed(1)}%`;
+            return (
+              <Link
+                key={entry.submission_id}
+                href={`/model/${entry.provider.toLowerCase()}/${entry.model}${officialOnly ? "" : "?official=false"}`}
+                className="rounded-2xl border border-border bg-card p-5 transition-colors hover:border-primary/60"
+              >
+                <div className="mb-4 flex items-center justify-between">
+                  <span className="text-2xl">{index === 0 ? "🦞" : index === 1 ? "🦀" : "🦐"}</span>
+                  <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">#{index + 1}</span>
+                </div>
+                <code className="block truncate text-lg font-bold text-foreground">{entry.model}</code>
+                <p className="mt-1 text-sm text-muted-foreground">via {entry.provider}</p>
+                <div className="mt-4 flex items-end justify-between gap-3">
+                  <span className="text-2xl font-bold text-foreground">{metric}</span>
+                  <span className="text-sm text-muted-foreground">{formatCost(entry.best_cost_usd)}</span>
+                </div>
+              </Link>
+            );
+          })}
+        </section>
+
+        <section className="rounded-2xl border border-border bg-card p-5">
+          <h2 className="text-xl font-bold text-foreground">What This Tests</h2>
+          <p className="mt-3 max-w-4xl text-sm leading-relaxed text-muted-foreground">{config.taskSummary}</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {BEST_FOR_CATEGORIES.map((item) => (
+              <Link
+                key={item.slug}
+                href={`/best-for/${item.slug}`}
+                className={`rounded-full border px-3 py-1 text-sm transition-colors ${item.slug === config.slug ? "border-primary bg-primary/10 text-primary" : "border-border text-muted-foreground hover:text-foreground"}`}
+              >
+                {item.navLabel}
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-border bg-card p-5">
+          <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-bold text-foreground">Top 5 Comparison</h2>
+              <p className="text-sm text-muted-foreground">Side-by-side metrics for the strongest recommendations on this page.</p>
+            </div>
+            <Link
+              href={`/?view=graphs&graph=radar&models=${encodeURIComponent(comparisonEntries.map((entry) => entry.model).slice(0, 3).join(","))}${officialOnly ? "" : "&official=false"}`}
+              className="text-sm text-primary hover:underline"
+            >
+              Open comparison tool
+            </Link>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[720px] text-sm">
+              <thead className="border-b border-border bg-muted/30 text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-3 py-3 text-left">Rank</th>
+                  <th className="px-3 py-3 text-left">Model</th>
+                  <th className="px-3 py-3 text-right">Overall</th>
+                  <th className="px-3 py-3 text-right">Use-Case Score</th>
+                  <th className="px-3 py-3 text-right">Cost</th>
+                  <th className="px-3 py-3 text-right">Avg Time</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {comparisonEntries.map((entry, index) => {
+                  const categoryScore = config.category ? getCategoryScore(entry, config.category) : null;
+                  const useCaseScore = config.slug === "budget"
+                    ? `${entry.value_score?.toFixed(1) ?? "N/A"} value`
+                    : `${categoryScore?.scorePercentage.toFixed(1) ?? entry.percentage.toFixed(1)}%`;
+                  return (
+                    <tr key={entry.submission_id} className="hover:bg-muted/20">
+                      <td className="px-3 py-3 text-muted-foreground">#{index + 1}</td>
+                      <td className="px-3 py-3">
+                        <Link href={`/model/${entry.provider.toLowerCase()}/${entry.model}${officialOnly ? "" : "?official=false"}`} className="hover:text-primary">
+                          <code className="font-semibold">{entry.model}</code>
+                        </Link>
+                        <div className="text-xs text-muted-foreground">{entry.provider}</div>
+                      </td>
+                      <td className="px-3 py-3 text-right font-semibold">{entry.percentage.toFixed(1)}%</td>
+                      <td className="px-3 py-3 text-right font-semibold">{useCaseScore}</td>
+                      <td className="px-3 py-3 text-right">{formatCost(entry.best_cost_usd)}</td>
+                      <td className="px-3 py-3 text-right">{formatDuration(entry.average_execution_time_seconds)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
-import { fetchLeaderboard, fetchBenchmarkVersions } from '@/lib/api'
+import { fetchLeaderboard, fetchBenchmarkVersions, fetchTransformedBestSubmissions } from '@/lib/api'
 import { calculateRanks, transformLeaderboardEntry } from '@/lib/transforms'
+import { enrichEntriesWithSubmissions, getCategoryChampionBadges, getQuickRecommendations } from '@/lib/recommendations'
 import { LeaderboardView } from '@/components/leaderboard-view'
 
 interface HomeProps {
@@ -51,6 +52,11 @@ export default async function Home({ searchParams }: HomeProps) {
     fetchBenchmarkVersions(),
   ])
   const entries = calculateRanks(response.leaderboard.map(transformLeaderboardEntry))
+  const topCandidateIds = entries.slice(0, 40).map((entry) => entry.submission_id)
+  const topSubmissions = await fetchTransformedBestSubmissions(topCandidateIds)
+  const enrichedEntries = enrichEntriesWithSubmissions(entries, topSubmissions)
+  const quickPicks = getQuickRecommendations(enrichedEntries)
+  const championBadges = Object.fromEntries(getCategoryChampionBadges(enrichedEntries))
   const latestTimestamp = entries.reduce((latest, entry) => {
     const current = new Date(entry.timestamp).getTime()
     return Number.isNaN(current) ? latest : Math.max(latest, current)
@@ -73,6 +79,8 @@ export default async function Home({ searchParams }: HomeProps) {
       versions={versionsResponse.versions}
       currentVersion={version ?? null}
       officialOnly={officialOnly}
+      quickPicks={quickPicks}
+      championBadges={championBadges}
     />
   )
 }

--- a/components/leaderboard-header.tsx
+++ b/components/leaderboard-header.tsx
@@ -84,6 +84,12 @@ export function LeaderboardHeader({
                             >
                                 About
                             </Link>
+                            <Link
+                                href="/best-for/coding"
+                                className="px-3 py-1 rounded-md text-sm font-medium text-foreground hover:bg-secondary transition-colors"
+                            >
+                                Best For
+                            </Link>
                             <a
                                 href="https://github.com/pinchbench/skill"
                                 target="_blank"

--- a/components/leaderboard-view.tsx
+++ b/components/leaderboard-view.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
-import type { LeaderboardEntry, BenchmarkVersion } from '@/lib/types'
+import type { BestForBadge, LeaderboardEntry, BenchmarkVersion, RecommendationPick } from '@/lib/types'
 import { PROVIDER_COLORS } from '@/lib/types'
 import { SimpleLeaderboard } from '@/components/simple-leaderboard'
 import { ScatterGraphs } from '@/components/scatter-graphs'
@@ -11,6 +11,7 @@ import { ScoreDistribution } from '@/components/score-distribution'
 import { ModelRadar } from '@/components/model-radar'
 import { LeaderboardHeader } from '@/components/leaderboard-header'
 import { KiloClawAdCard } from '@/components/kiloclaw-ad-card'
+import { QuickPicks } from '@/components/quick-picks'
 
 type ViewMode = 'success' | 'speed' | 'cost' | 'value' | 'graphs'
 type ScoreMode = 'best' | 'average'
@@ -32,9 +33,11 @@ interface LeaderboardViewProps {
     versions: BenchmarkVersion[]
     currentVersion: string | null
     officialOnly: boolean
+    quickPicks?: RecommendationPick[]
+    championBadges?: Record<string, BestForBadge[]>
 }
 
-export function LeaderboardView({ entries, lastUpdated, versions, currentVersion, officialOnly }: LeaderboardViewProps) {
+export function LeaderboardView({ entries, lastUpdated, versions, currentVersion, officialOnly, quickPicks = [], championBadges = {} }: LeaderboardViewProps) {
     const searchParams = useSearchParams()
     const router = useRouter()
     const pathname = usePathname()
@@ -206,15 +209,19 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                         <KiloClawAdCard />
                     </div>
                 ) : (
-                    <SimpleLeaderboard
-                        entries={filteredEntries}
-                        view={view as 'success' | 'speed' | 'cost' | 'value'}
-                        scoreMode={scoreMode}
-                        benchmarkVersion={currentVersion}
-                        officialOnly={officialOnlyState}
-                        onScoreModeChange={setScoreMode}
-                        onProviderClick={setProviderFilter}
-                    />
+                    <>
+                        {view === 'success' && <QuickPicks picks={quickPicks} />}
+                        <SimpleLeaderboard
+                            entries={filteredEntries}
+                            view={view as 'success' | 'speed' | 'cost' | 'value'}
+                            scoreMode={scoreMode}
+                            benchmarkVersion={currentVersion}
+                            officialOnly={officialOnlyState}
+                            championBadges={championBadges}
+                            onScoreModeChange={setScoreMode}
+                            onProviderClick={setProviderFilter}
+                        />
+                    </>
                 )}
             </main>
         </div>

--- a/components/model-radar.tsx
+++ b/components/model-radar.tsx
@@ -21,7 +21,7 @@ interface ModelRadarProps {
   scoreMode: 'best' | 'average'
 }
 
-const MAX_SELECTED = 4
+const MAX_SELECTED = 3
 
 // Distinct colors for the overlay lines (not provider-based since overlays need contrast)
 const RADAR_COLORS = [
@@ -169,6 +169,11 @@ export function ModelRadar({ entries, scoreMode }: ModelRadarProps) {
     return { metrics: metricsMap, radarData: data }
   }, [entries, scoreMode, selectedModels])
 
+  const selectedEntries = useMemo(
+    () => selectedModels.map((model) => entries.find((entry) => entry.model === model)).filter(Boolean) as LeaderboardEntry[],
+    [entries, selectedModels]
+  )
+
   const toggleModel = (model: string) => {
     setSelectedModels(prev => {
       let next: string[]
@@ -206,12 +211,10 @@ export function ModelRadar({ entries, scoreMode }: ModelRadarProps) {
   return (
     <div>
       <h2 className="text-lg font-semibold text-foreground mb-1">
-        Multi-Dimensional Model Comparison
+        Model Comparison Tool
       </h2>
       <p className="text-sm text-muted-foreground mb-4">
-        Select up to {MAX_SELECTED} models to compare across score, cost efficiency (cheaper = better),
-        speed (faster = better), and consistency (avg/best score ratio).
-        All axes are normalized to 0-100.
+        Select 2-{MAX_SELECTED} models to compare overall score, speed, cost, and normalized efficiency metrics side by side.
       </p>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -358,22 +361,46 @@ export function ModelRadar({ entries, scoreMode }: ModelRadarProps) {
                     <thead>
                       <tr className="border-b border-border">
                         <th className="text-left py-1.5 px-2 text-muted-foreground font-medium">Metric</th>
-                        {selectedModels.map((model, i) => (
-                          <th key={model} className="text-right py-1.5 px-2 font-medium" style={{ color: RADAR_COLORS[i] }}>
-                            {model}
+                        {selectedEntries.map((entry, i) => (
+                          <th key={entry.model} className="text-right py-1.5 px-2 font-medium" style={{ color: RADAR_COLORS[i] }}>
+                            {entry.model}
                           </th>
                         ))}
                       </tr>
                     </thead>
                     <tbody>
-                      {['Score', 'Cost Efficiency', 'Speed', 'Consistency'].map((axis) => (
+                      <tr className="border-b border-border/50">
+                        <td className="py-1.5 px-2 text-muted-foreground">Overall</td>
+                        {selectedEntries.map((entry) => (
+                          <td key={entry.model} className="text-right py-1.5 px-2 font-medium text-foreground">
+                            {entry.percentage.toFixed(1)}%
+                          </td>
+                        ))}
+                      </tr>
+                      <tr className="border-b border-border/50">
+                        <td className="py-1.5 px-2 text-muted-foreground">Cost per run</td>
+                        {selectedEntries.map((entry) => (
+                          <td key={entry.model} className="text-right py-1.5 px-2 font-medium text-foreground">
+                            {entry.best_cost_usd == null ? '-' : `$${entry.best_cost_usd.toFixed(3)}`}
+                          </td>
+                        ))}
+                      </tr>
+                      <tr className="border-b border-border/50">
+                        <td className="py-1.5 px-2 text-muted-foreground">Avg time</td>
+                        {selectedEntries.map((entry) => (
+                          <td key={entry.model} className="text-right py-1.5 px-2 font-medium text-foreground">
+                            {entry.average_execution_time_seconds == null ? '-' : `${(entry.average_execution_time_seconds / 60).toFixed(1)}m`}
+                          </td>
+                        ))}
+                      </tr>
+                      {['Cost Efficiency', 'Speed', 'Consistency'].map((axis) => (
                         <tr key={axis} className="border-b border-border/50">
                           <td className="py-1.5 px-2 text-muted-foreground">{axis}</td>
-                          {selectedModels.map((model) => {
+                          {selectedEntries.map((entry) => {
                             const dataPoint = radarData.find(d => d.axis === axis)
-                            const value = dataPoint?.[model] as number | undefined
+                            const value = dataPoint?.[entry.model] as number | undefined
                             return (
-                              <td key={model} className="text-right py-1.5 px-2 font-medium text-foreground">
+                              <td key={entry.model} className="text-right py-1.5 px-2 font-medium text-foreground">
                                 {value != null ? value : '-'}
                               </td>
                             )

--- a/components/quick-picks.tsx
+++ b/components/quick-picks.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import type { RecommendationPick } from "@/lib/types";
+import { formatCost } from "@/lib/recommendations";
+
+interface QuickPicksProps {
+  picks: RecommendationPick[];
+}
+
+export function QuickPicks({ picks }: QuickPicksProps) {
+  if (picks.length === 0) return null;
+
+  return (
+    <section className="mb-8 rounded-2xl border border-primary/25 bg-gradient-to-br from-primary/10 via-card to-card p-4 shadow-sm md:p-5">
+      <div className="mb-4 flex flex-col gap-1 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">Quick Picks</p>
+          <h2 className="text-xl font-bold text-foreground">Best AI models for common use cases</h2>
+        </div>
+        <Link href="/best-for/coding" className="text-sm text-primary hover:underline">
+          Explore best-for guides
+        </Link>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {picks.map((pick) => (
+          <Link
+            key={pick.key}
+            href={pick.href}
+            className="group rounded-xl border border-border bg-background/70 p-4 transition-colors hover:border-primary/60 hover:bg-background"
+          >
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <span className="text-xl" aria-hidden="true">{pick.icon}</span>
+                <span className="font-semibold text-foreground">{pick.label}</span>
+              </div>
+              <span className="rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                {pick.metricValue}
+              </span>
+            </div>
+            <code className="block truncate text-sm font-semibold text-foreground group-hover:text-primary">
+              {pick.entry.model}
+            </code>
+            <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+              <span>{pick.metricLabel}</span>
+              <span>{pick.entry.percentage.toFixed(1)}% overall · {formatCost(pick.entry.best_cost_usd)}</span>
+            </div>
+            <p className="mt-3 text-xs leading-relaxed text-muted-foreground">{pick.description}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/simple-leaderboard.tsx
+++ b/components/simple-leaderboard.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { DEFAULT_TABLE_ROW_LIMIT } from '@/lib/constants'
-import type { LeaderboardEntry, SortMode } from '@/lib/types'
+import type { BestForBadge, LeaderboardEntry, SortMode } from '@/lib/types'
 import { PROVIDER_COLORS } from '@/lib/types'
 import { ShareableWrapper } from '@/components/shareable-wrapper'
 import { KiloClawAdCard } from '@/components/kiloclaw-ad-card'
@@ -18,6 +18,7 @@ interface SimpleLeaderboardProps {
   scoreMode: 'best' | 'average'
   benchmarkVersion?: string | null
   officialOnly: boolean
+  championBadges?: Record<string, BestForBadge[]>
   onScoreModeChange?: (mode: 'best' | 'average') => void
   onProviderClick?: (provider: string) => void
 }
@@ -88,6 +89,7 @@ export function SimpleLeaderboard({
   scoreMode,
   benchmarkVersion,
   officialOnly,
+  championBadges = {},
   onScoreModeChange,
   onProviderClick,
 }: SimpleLeaderboardProps) {
@@ -218,6 +220,27 @@ export function SimpleLeaderboard({
 
   const modelHref = (provider: string, model: string) =>
     `/model/${provider.toLowerCase()}/${model}${officialOnly ? '' : '?official=false'}`
+
+  const renderBadges = (entry: LeaderboardEntry) => {
+    const badges = championBadges[entry.submission_id] ?? []
+    if (badges.length === 0) return null
+
+    return (
+      <span className="flex flex-wrap items-center gap-1">
+        {badges.slice(0, 3).map((badge) => (
+          <span
+            key={badge.key}
+            className="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-400/10 px-2 py-0.5 text-[10px] font-semibold text-amber-200"
+            title={`${badge.label} category champion`}
+          >
+            <span aria-hidden="true">👑</span>
+            <span aria-hidden="true">{badge.icon}</span>
+            {badge.label}
+          </span>
+        ))}
+      </span>
+    )
+  }
 
   // ----------------------------------------------------------------
   // VALUE view
@@ -566,6 +589,7 @@ export function SimpleLeaderboard({
                             <code className="text-xs font-mono text-foreground transition-colors truncate">
                               {entry.model}
                             </code>
+                            {renderBadges(entry)}
                             {entry.official === false && (
                               <span className="rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-300">
                                 Unofficial
@@ -751,6 +775,7 @@ export function SimpleLeaderboard({
                         >
                           <span className="text-lg">{getCrabEmoji(entry.rank)}</span>
                           <code className="text-xs md:text-sm font-mono truncate max-w-[180px] md:max-w-none">{entry.model}</code>
+                          {renderBadges(entry)}
                           {entry.official === false && (
                             <span className="rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-300">
                               Unofficial

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  ApiSubmissionDetail,
   LeaderboardResponse,
   SubmissionDetailResponse,
   SubmissionsListResponse,
@@ -7,6 +8,7 @@ import type {
   ModelSubmissionsResponse,
   UserSubmissionsResponse,
 } from "@/lib/types";
+import { transformSubmission } from "@/lib/transforms";
 
 const API_BASE = "https://api.pinchbench.com/api";
 
@@ -62,6 +64,24 @@ export async function fetchSubmission(
   id: string,
 ): Promise<SubmissionDetailResponse> {
   return fetchJson<SubmissionDetailResponse>(`/submissions/${id}`);
+}
+
+export async function fetchBestSubmissionDetails(
+  submissionIds: string[],
+): Promise<ApiSubmissionDetail[]> {
+  const uniqueIds = [...new Set(submissionIds.filter(Boolean))];
+  const responses = await Promise.allSettled(
+    uniqueIds.map((id) => fetchSubmission(id)),
+  );
+
+  return responses.flatMap((response) =>
+    response.status === "fulfilled" ? [response.value.submission] : [],
+  );
+}
+
+export async function fetchTransformedBestSubmissions(submissionIds: string[]) {
+  const submissions = await fetchBestSubmissionDetails(submissionIds);
+  return submissions.map((submission) => transformSubmission(submission));
 }
 
 export async function fetchSubmissions(

--- a/lib/recommendations.ts
+++ b/lib/recommendations.ts
@@ -1,0 +1,253 @@
+import type {
+  BestForBadge,
+  CategoryScore,
+  EnrichedLeaderboardEntry,
+  LeaderboardEntry,
+  RecommendationPick,
+  Submission,
+} from "@/lib/types";
+import { CATEGORY_ICONS } from "@/lib/types";
+
+export const BEST_FOR_CATEGORIES = [
+  {
+    slug: "coding",
+    category: "coding",
+    title: "Best AI Model for Coding in 2026",
+    navLabel: "Coding",
+    description:
+      "Compare the leading AI coding agents on PinchBench tasks that require writing scripts, editing files, and completing developer workflows.",
+    taskSummary:
+      "Coding pages focus on benchmark tasks categorized as coding, including script generation and file operations. Scores come from the best verified submission for each model.",
+  },
+  {
+    slug: "data-analysis",
+    category: "api",
+    title: "Best AI for Data Analysis",
+    navLabel: "Data Analysis",
+    description:
+      "Find models that perform well on data-oriented research and API tasks where the agent must gather, transform, and present structured information.",
+    taskSummary:
+      "Data analysis uses API and data-retrieval tasks as the closest available PinchBench proxy for structured data work.",
+  },
+  {
+    slug: "budget",
+    category: null,
+    title: "Best Cheap AI Models",
+    navLabel: "Budget",
+    description:
+      "Rank models by useful benchmark quality at the lowest observed run cost, highlighting inexpensive and high-value OpenClaw agent options.",
+    taskSummary:
+      "Budget recommendations use Value Score, defined as success percentage divided by best observed cost per run. Models without usable cost data are excluded.",
+  },
+] as const;
+
+export type BestForSlug = (typeof BEST_FOR_CATEGORIES)[number]["slug"];
+
+export function getBestForConfig(slug: string) {
+  return BEST_FOR_CATEGORIES.find((config) => config.slug === slug) ?? null;
+}
+
+export function formatCost(cost: number | null | undefined): string {
+  if (cost == null) return "N/A";
+  if (cost === 0) return "FREE";
+  return `$${cost.toFixed(cost < 1 ? 3 : 2)}`;
+}
+
+export function formatDuration(seconds: number | null | undefined): string {
+  if (seconds == null) return "N/A";
+  if (seconds >= 60) return `${(seconds / 60).toFixed(1)}m`;
+  return `${seconds.toFixed(1)}s`;
+}
+
+export function getCategoryScores(submission: Submission): CategoryScore[] {
+  const byCategory = new Map<string, { score: number; maxScore: number; taskCount: number }>();
+
+  for (const task of submission.task_results) {
+    const category = task.category || "other";
+    const existing = byCategory.get(category) ?? { score: 0, maxScore: 0, taskCount: 0 };
+    existing.score += task.score;
+    existing.maxScore += task.max_score;
+    existing.taskCount += 1;
+    byCategory.set(category, existing);
+  }
+
+  return Array.from(byCategory.entries())
+    .map(([category, totals]) => ({
+      category,
+      scorePercentage: totals.maxScore > 0 ? (totals.score / totals.maxScore) * 100 : 0,
+      taskCount: totals.taskCount,
+    }))
+    .sort((a, b) => a.category.localeCompare(b.category));
+}
+
+export function enrichEntriesWithSubmissions(
+  entries: LeaderboardEntry[],
+  submissions: Submission[],
+): EnrichedLeaderboardEntry[] {
+  const scoresBySubmission = new Map(
+    submissions.map((submission) => [submission.submission_id, getCategoryScores(submission)]),
+  );
+
+  return entries.map((entry) => ({
+    ...entry,
+    categoryScores: scoresBySubmission.get(entry.submission_id) ?? [],
+  }));
+}
+
+export function getCategoryScore(
+  entry: EnrichedLeaderboardEntry,
+  category: string,
+): CategoryScore | null {
+  return entry.categoryScores.find((score) => score.category === category) ?? null;
+}
+
+export function sortEntriesForBestFor(
+  entries: EnrichedLeaderboardEntry[],
+  slug: BestForSlug,
+): EnrichedLeaderboardEntry[] {
+  const config = getBestForConfig(slug);
+  if (!config) return entries;
+
+  if (config.slug === "budget") {
+    return [...entries]
+      .filter((entry) => entry.best_cost_usd != null && entry.best_cost_usd > 0 && entry.value_score != null)
+      .sort((a, b) => (b.value_score ?? -1) - (a.value_score ?? -1));
+  }
+
+  if (!config.category) return entries;
+
+  return [...entries]
+    .filter((entry) => getCategoryScore(entry, config.category!) != null)
+    .sort((a, b) => {
+      const aScore = getCategoryScore(a, config.category!)?.scorePercentage ?? -1;
+      const bScore = getCategoryScore(b, config.category!)?.scorePercentage ?? -1;
+      if (Math.abs(bScore - aScore) > 1e-9) return bScore - aScore;
+      return b.percentage - a.percentage;
+    });
+}
+
+export function getCategoryChampionBadges(entries: EnrichedLeaderboardEntry[]): Map<string, BestForBadge[]> {
+  const badges = new Map<string, BestForBadge[]>();
+  const categories = new Set<string>();
+
+  for (const entry of entries) {
+    for (const score of entry.categoryScores) {
+      categories.add(score.category);
+    }
+  }
+
+  for (const category of categories) {
+    const champion = [...entries]
+      .filter((entry) => getCategoryScore(entry, category) != null)
+      .sort((a, b) => {
+        const aScore = getCategoryScore(a, category)?.scorePercentage ?? -1;
+        const bScore = getCategoryScore(b, category)?.scorePercentage ?? -1;
+        if (Math.abs(bScore - aScore) > 1e-9) return bScore - aScore;
+        return b.percentage - a.percentage;
+      })[0];
+
+    if (!champion) continue;
+
+    const current = badges.get(champion.submission_id) ?? [];
+    current.push({
+      key: `category-${category}`,
+      label: titleCase(category),
+      icon: CATEGORY_ICONS[category] ?? "👑",
+    });
+    badges.set(champion.submission_id, current);
+  }
+
+  return badges;
+}
+
+export function getQuickRecommendations(entries: EnrichedLeaderboardEntry[]): RecommendationPick[] {
+  const bestOverall = [...entries].sort((a, b) => b.percentage - a.percentage)[0];
+  const fastest = [...entries]
+    .filter((entry) => entry.best_execution_time_seconds != null)
+    .sort((a, b) => (a.best_execution_time_seconds ?? Infinity) - (b.best_execution_time_seconds ?? Infinity))[0];
+  const cheapest = [...entries]
+    .filter((entry) => entry.best_cost_usd != null && entry.best_cost_usd > 0)
+    .sort((a, b) => (a.best_cost_usd ?? Infinity) - (b.best_cost_usd ?? Infinity))[0];
+  const bestValue = sortEntriesForBestFor(entries, "budget")[0];
+  const bestCode = sortEntriesForBestFor(entries, "coding")[0];
+  const bestData = sortEntriesForBestFor(entries, "data-analysis")[0];
+
+  const picks: Array<RecommendationPick | null | undefined> = [
+    bestOverall && {
+      key: "overall",
+      label: "Best Overall",
+      shortLabel: "Overall",
+      icon: "👑",
+      description: "Highest verified success rate across the benchmark.",
+      href: "/",
+      entry: bestOverall,
+      metricLabel: "Score",
+      metricValue: `${bestOverall.percentage.toFixed(1)}%`,
+    },
+    fastest && {
+      key: "speed",
+      label: "Fastest",
+      shortLabel: "Speed",
+      icon: "⚡",
+      description: "Lowest observed complete benchmark runtime.",
+      href: "/?view=speed",
+      entry: fastest,
+      metricLabel: "Best Time",
+      metricValue: formatDuration(fastest.best_execution_time_seconds),
+    },
+    cheapest && {
+      key: "budget",
+      label: "Best Budget",
+      shortLabel: "Budget",
+      icon: "💰",
+      description: "Lowest observed non-zero benchmark run cost.",
+      href: "/best-for/budget",
+      entry: cheapest,
+      metricLabel: "Best Cost",
+      metricValue: formatCost(cheapest.best_cost_usd),
+    },
+    bestValue && {
+      key: "value",
+      label: "Best Value",
+      shortLabel: "Value",
+      icon: "💎",
+      description: "Best success percentage per dollar.",
+      href: "/?view=value",
+      entry: bestValue,
+      metricLabel: "Value Score",
+      metricValue: bestValue.value_score?.toFixed(1) ?? "N/A",
+    },
+    bestCode && {
+      key: "coding",
+      label: "Best for Code",
+      shortLabel: "Code",
+      icon: "🔧",
+      description: "Highest score on coding-category tasks.",
+      href: "/best-for/coding",
+      entry: bestCode,
+      metricLabel: "Coding Score",
+      metricValue: `${getCategoryScore(bestCode, "coding")?.scorePercentage.toFixed(1) ?? bestCode.percentage.toFixed(1)}%`,
+    },
+    bestData && {
+      key: "data",
+      label: "Best for Data",
+      shortLabel: "Data",
+      icon: "📊",
+      description: "Highest score on data-oriented API tasks.",
+      href: "/best-for/data-analysis",
+      entry: bestData,
+      metricLabel: "Data Score",
+      metricValue: `${getCategoryScore(bestData, "api")?.scorePercentage.toFixed(1) ?? bestData.percentage.toFixed(1)}%`,
+    },
+  ];
+
+  return picks.filter((pick): pick is RecommendationPick => Boolean(pick));
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,6 +20,34 @@ export interface LeaderboardEntry {
   official?: boolean;
 }
 
+export interface CategoryScore {
+  category: string;
+  scorePercentage: number;
+  taskCount: number;
+}
+
+export interface EnrichedLeaderboardEntry extends LeaderboardEntry {
+  categoryScores: CategoryScore[];
+}
+
+export interface BestForBadge {
+  key: string;
+  label: string;
+  icon: string;
+}
+
+export interface RecommendationPick {
+  key: string;
+  label: string;
+  shortLabel: string;
+  icon: string;
+  description: string;
+  href: string;
+  entry: LeaderboardEntry;
+  metricLabel: string;
+  metricValue: string;
+}
+
 export interface TaskResult {
   task_id: string;
   task_name: string;


### PR DESCRIPTION
## Summary

- Added Quick Picks recommendation cards to the homepage for best overall, fastest, budget, value, coding, and data-oriented model choices.
- Added category champion badges to leaderboard rows so top models are easier to identify at a glance.
- Added SEO landing pages for `/best-for/coding`, `/best-for/data-analysis`, and `/best-for/budget`.
- Expanded the model comparison tool with side-by-side metrics and a 2-3 model comparison flow.
- Centralized recommendation scoring, formatting, enrichment, and badge generation in shared utilities.
- Updated documentation to describe the recommendation data flow and new user-facing features.

## Implementation Notes

- Leaderboard entries are enriched with best submission details so category/task scores can be derived without requiring a new backend endpoint.
- Recommendation logic lives in `lib/recommendations.ts` and is reused by the homepage and best-for landing pages.
- Best-for landing pages include hero content, recommendation cards, task/category explanations, navigation between use cases, and top comparison tables.
- The model comparison UI now focuses on comparing up to three models side by side, including score, cost, speed, value, consistency, and provider details.

## Validation

- `bun run build` passes.
- Browser QA was started across homepage and best-for pages at desktop, tablet, and mobile sizes.
- Console checks during QA did not show JavaScript errors or warnings beyond normal development logs.

## Known Follow-Ups

- `bunx tsc --noEmit` still reports pre-existing unrelated type issues:
  - `lib/badges.test.ts` cannot resolve `bun:test` types.
  - `lib/mock-data.ts` mock submission is missing `benchmark_version`.
- `/best-for/data-analysis` currently needs a data fallback/category mapping adjustment if the active benchmark data does not include the expected category scores.
- Metric champion badges for speed/value may be added if strict parity with the issue examples is required.
- These change may close #89.
- Few screens:
<img width="1185" height="3103" alt="image" src="https://github.com/user-attachments/assets/70926a73-dd24-4492-bce2-4a516a4af70b" />
<img width="1185" height="1491" alt="image" src="https://github.com/user-attachments/assets/8d00a63d-db7c-4847-a1e8-fa5c37bcf9f7" />
<img width="1425" height="1849" alt="image" src="https://github.com/user-attachments/assets/ceab0481-2c09-46ef-aa57-1f68358a1bba" />
<img width="1425" height="1849" alt="image" src="https://github.com/user-attachments/assets/61062392-744d-4192-8eb6-b80849a6be82" />
