### PR TITLE
feat(task-categories): add task category filtering and breakdown views

### DIFF
--- a/app/model/[...slug]/page.tsx
+++ b/app/model/[...slug]/page.tsx
@@ -5,9 +5,13 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { ArrowLeft, BarChart3, Clock, DollarSign, Activity } from 'lucide-react'
 import { PROVIDER_COLORS } from '@/lib/types'
-import { fetchModelSubmissions } from '@/lib/api'
+import { fetchModelSubmissions, fetchSubmission } from '@/lib/api'
+import { aggregateCategoryScores } from '@/lib/category-scores'
+import { transformSubmission } from '@/lib/transforms'
 import { formatDistanceToNow } from 'date-fns'
 import { ModelScoreTrend } from '@/components/model-score-trend'
+
+type CategoryScore = ReturnType<typeof aggregateCategoryScores>[number]
 
 interface ModelPageProps {
   params: Promise<{ slug: string[] }>
@@ -59,6 +63,18 @@ export default async function ModelPage({ params, searchParams }: ModelPageProps
 
   const avgCost = submissions.reduce((a, b) => a + (b.total_cost_usd || 0), 0) / submissions.length
   const avgSpeed = submissions.reduce((a, b) => a + (b.total_execution_time_seconds || 0), 0) / submissions.length
+  const bestSubmission = submissions.reduce((best, submission) =>
+    submission.score_percentage > best.score_percentage ? submission : best
+  )
+  let categoryScores: CategoryScore[] = []
+  try {
+    const detail = await fetchSubmission(bestSubmission.id)
+    categoryScores = aggregateCategoryScores(
+      transformSubmission(detail.submission).task_results,
+    )
+  } catch {
+    categoryScores = []
+  }
 
   const compareUrl = `/?view=graphs&graph=radar&models=${encodeURIComponent(modelName)}${officialOnly ? '' : '&official=false'}`
 
@@ -141,6 +157,54 @@ export default async function ModelPage({ params, searchParams }: ModelPageProps
             <span className="text-2xl font-bold">{avgSpeed.toFixed(1)}s</span>
           </Card>
         </div>
+
+        {/* Score Trend Chart */}
+        {categoryScores.length > 0 && (
+          <Card className="p-6">
+            <div className="flex flex-col gap-1 mb-4">
+              <h3 className="text-lg font-semibold">Best Run Category Breakdown</h3>
+              <p className="text-sm text-muted-foreground">
+                Category scores from this model&apos;s best submission ({(bestSubmission.score_percentage * 100).toFixed(1)}%).
+              </p>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3">
+              {categoryScores.map((category) => {
+                const color = category.percentage >= 85
+                  ? 'text-green-500'
+                  : category.percentage >= 70
+                    ? 'text-yellow-500'
+                    : 'text-red-500'
+
+                return (
+                  <div key={category.category} className="rounded-lg border border-border bg-muted/20 p-4">
+                    <div className="flex items-center justify-between gap-2 mb-3">
+                      <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                        {category.icon} {category.shortLabel}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {category.count} tasks
+                      </span>
+                    </div>
+                    <div className="flex items-end justify-between gap-2 mb-2">
+                      <span className={`text-2xl font-bold ${color}`}>
+                        {category.percentage.toFixed(0)}%
+                      </span>
+                      <span className="text-xs font-mono text-muted-foreground">
+                        {category.total.toFixed(1)} / {category.max.toFixed(1)}
+                      </span>
+                    </div>
+                    <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-primary"
+                        style={{ width: `${Math.min(100, Math.max(0, category.percentage))}%` }}
+                      />
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </Card>
+        )}
 
         {/* Score Trend Chart */}
         <Card className="p-6">

--- a/app/submission/[id]/page.tsx
+++ b/app/submission/[id]/page.tsx
@@ -16,6 +16,7 @@ import { PROVIDER_COLORS } from '@/lib/types'
 import { formatDistanceToNow } from 'date-fns'
 import { fetchSubmission } from '@/lib/api'
 import { transformSubmission } from '@/lib/transforms'
+import { aggregateCategoryScores } from '@/lib/category-scores'
 
 interface SubmissionPageProps {
   params: Promise<{ id: string }>
@@ -76,18 +77,7 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
     notFound()
   }
 
-  const categoryStats = submission.task_results.reduce(
-    (acc, task) => {
-      if (!acc[task.category]) {
-        acc[task.category] = { total: 0, max: 0, count: 0 }
-      }
-      acc[task.category].total += task.score
-      acc[task.category].max += task.max_score
-      acc[task.category].count += 1
-      return acc
-    },
-    {} as Record<string, { total: number; max: number; count: number }>
-  )
+  const categoryStats = aggregateCategoryScores(submission.task_results)
 
   const badgeStatuses = await getModelBadgeStatuses(submission.model, {
     officialOnly,
@@ -256,8 +246,8 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
           </div>
 
           <div className="lg:col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {Object.entries(categoryStats).map(([category, stats]) => {
-              const percentage = (stats.total / stats.max) * 100
+            {categoryStats.map((stats) => {
+              const percentage = stats.percentage
               const getColor = () => {
                 if (percentage >= 85) return 'text-green-500'
                 if (percentage >= 70) return 'text-yellow-500'
@@ -266,11 +256,11 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
 
               return (
                 <Card
-                  key={category}
+                  key={stats.category}
                   className="p-4 bg-card border-border flex flex-col"
                 >
                   <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">
-                    {category}
+                    {stats.icon} {stats.label}
                   </div>
                   <div className="flex items-baseline gap-2 mb-1">
                     <span className={`text-2xl font-bold ${getColor()}`}>

--- a/components/category-pills.tsx
+++ b/components/category-pills.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { TASK_CATEGORIES } from '@/lib/types'
+
+interface CategoryPillsProps {
+  selectedCategories: string[]
+  onCategoriesChange: (categories: string[]) => void
+  disabled?: boolean
+  activeTaskCount?: number | null
+  className?: string
+}
+
+export function CategoryPills({
+  selectedCategories,
+  onCategoriesChange,
+  disabled = false,
+  activeTaskCount,
+  className = '',
+}: CategoryPillsProps) {
+  const selected = new Set(selectedCategories)
+  const hasFilter = selectedCategories.length > 0
+
+  const toggleCategory = (category: string) => {
+    if (disabled) return
+    onCategoriesChange(
+      selected.has(category)
+        ? selectedCategories.filter((c) => c !== category)
+        : [...selectedCategories, category],
+    )
+  }
+
+  return (
+    <div className={`flex flex-wrap items-center gap-2 ${className}`} data-share-exclude="true">
+      <span className="text-xs font-medium text-muted-foreground shrink-0">
+        Category:
+      </span>
+      <button
+        type="button"
+        onClick={() => onCategoriesChange([])}
+        disabled={disabled}
+        className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors border disabled:opacity-60 disabled:cursor-wait ${
+          !hasFilter
+            ? 'bg-primary text-primary-foreground border-primary'
+            : 'bg-secondary text-secondary-foreground border-border hover:bg-secondary/80'
+        }`}
+      >
+        All
+      </button>
+      {TASK_CATEGORIES.map((category) => {
+        const active = selected.has(category.id)
+        return (
+          <button
+            key={category.id}
+            type="button"
+            onClick={() => toggleCategory(category.id)}
+            disabled={disabled}
+            title={category.description}
+            aria-pressed={active}
+            className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors border disabled:opacity-60 disabled:cursor-wait ${
+              active
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-secondary text-secondary-foreground border-border hover:bg-secondary/80'
+            }`}
+          >
+            <span aria-hidden="true">{category.icon}</span>
+            <span>{category.shortLabel}</span>
+          </button>
+        )
+      })}
+      {hasFilter && activeTaskCount != null ? (
+        <span className="text-xs text-muted-foreground/70">
+          {activeTaskCount} task{activeTaskCount === 1 ? '' : 's'} selected
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/components/leaderboard-header.tsx
+++ b/components/leaderboard-header.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import type { BenchmarkVersion, LeaderboardEntry } from '@/lib/types'
 import { VersionSelector } from '@/components/version-selector'
 import { ModelSearch } from '@/components/model-search'
+import { CategoryPills } from '@/components/category-pills'
 
 type ViewMode = 'success' | 'speed' | 'cost' | 'value' | 'graphs'
 type ScoreMode = 'best' | 'average'
@@ -21,11 +22,15 @@ interface LeaderboardHeaderProps {
     scoreMode: ScoreMode
     officialOnly: boolean
     openWeightsOnly: boolean
+    selectedCategories: string[]
+    categoryDataLoading: boolean
+    activeCategoryTaskCount: number | null
     modelSearchValue: string
     onViewChange: (view: ViewMode) => void
     onScoreModeChange: (mode: ScoreMode) => void
     onOfficialOnlyChange: (officialOnly: boolean) => void
     onOpenWeightsOnlyChange: (openWeightsOnly: boolean) => void
+    onCategoriesChange: (categories: string[]) => void
     onClearProviderFilter: () => void
     onModelSearchChange: (value: string) => void
 }
@@ -43,11 +48,15 @@ export function LeaderboardHeader({
     scoreMode,
     officialOnly,
     openWeightsOnly,
+    selectedCategories,
+    categoryDataLoading,
+    activeCategoryTaskCount,
     modelSearchValue,
     onViewChange,
     onScoreModeChange,
     onOfficialOnlyChange,
     onOpenWeightsOnlyChange,
+    onCategoriesChange,
     onClearProviderFilter,
     onModelSearchChange,
 }: LeaderboardHeaderProps) {
@@ -148,6 +157,14 @@ export function LeaderboardHeader({
                         </span>
                     </div>
                 )}
+
+                <CategoryPills
+                    selectedCategories={selectedCategories}
+                    onCategoriesChange={onCategoriesChange}
+                    disabled={categoryDataLoading}
+                    activeTaskCount={activeCategoryTaskCount}
+                    className="mt-4"
+                />
 
                 {/* Navigation buttons - 2x3 grid on mobile, inline on desktop */}
                 <div className="grid grid-cols-3 gap-2 mt-4 md:mt-6 md:flex md:flex-wrap md:items-center">

--- a/components/leaderboard-view.tsx
+++ b/components/leaderboard-view.tsx
@@ -1,9 +1,12 @@
 'use client'
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
-import type { LeaderboardEntry, BenchmarkVersion } from '@/lib/types'
+import type { LeaderboardEntry, BenchmarkVersion, TaskResult } from '@/lib/types'
 import { PROVIDER_COLORS } from '@/lib/types'
+import { fetchSubmissionClient } from '@/lib/api'
+import { calculateCategoryFilteredScore, calculateRanksByPercentage } from '@/lib/category-scores'
+import { transformSubmission } from '@/lib/transforms'
 import { SimpleLeaderboard } from '@/components/simple-leaderboard'
 import { ScatterGraphs } from '@/components/scatter-graphs'
 import { TaskHeatmap } from '@/components/task-heatmap'
@@ -60,6 +63,9 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
     const [openWeightsOnly, setOpenWeightsOnlyState] = useState<boolean>(initialOpenWeights)
     const [graphSubTab, setGraphSubTabState] = useState<GraphSubTab>(initialGraphTab)
     const [modelSearch, setModelSearchState] = useState<string>(initialModelSearch)
+    const [taskDataBySubmission, setTaskDataBySubmission] = useState<Record<string, TaskResult[]>>({})
+    const [taskDataLoading, setTaskDataLoading] = useState(false)
+    const [taskDataError, setTaskDataError] = useState<string | null>(null)
 
     // Helper to update URL params without full page reload
     const updateUrl = useCallback((updates: Record<string, string | null>) => {
@@ -118,6 +124,8 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
         [searchParams]
     )
 
+    const categoryFilterActive = selectedCategories.length > 0
+
     const setSelectedCategories = useCallback((cats: string[]) => {
         const normalized = [...new Set(cats.map((c) => c.trim().toLowerCase()).filter(Boolean))]
         updateUrl({ categories: normalized.length ? normalized.join(',') : null })
@@ -131,6 +139,105 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
             return true
         })
     }, [entries, providerFilter, openWeightsOnly, modelSearch])
+
+    useEffect(() => {
+        if (!categoryFilterActive) {
+            setTaskDataLoading(false)
+            setTaskDataError(null)
+            return
+        }
+
+        const missingEntries = filteredEntries.filter(
+            (entry) => !taskDataBySubmission[entry.submission_id]
+        )
+
+        if (missingEntries.length === 0) {
+            setTaskDataLoading(false)
+            return
+        }
+
+        let cancelled = false
+
+        async function loadTaskData(entriesToLoad: LeaderboardEntry[]) {
+            setTaskDataLoading(true)
+            setTaskDataError(null)
+
+            try {
+                const loaded: Record<string, TaskResult[]> = {}
+                const batchSize = 5
+
+                for (let i = 0; i < entriesToLoad.length; i += batchSize) {
+                    if (cancelled) return
+                    const batch = entriesToLoad.slice(i, i + batchSize)
+                    const results = await Promise.all(
+                        batch.map(async (entry) => {
+                            try {
+                                const response = await fetchSubmissionClient(entry.submission_id)
+                                return {
+                                    submissionId: entry.submission_id,
+                                    tasks: transformSubmission(response.submission).task_results,
+                                }
+                            } catch {
+                                return null
+                            }
+                        })
+                    )
+
+                    for (const result of results) {
+                        if (result) loaded[result.submissionId] = result.tasks
+                    }
+                }
+
+                if (!cancelled) {
+                    setTaskDataBySubmission((current) => ({ ...current, ...loaded }))
+                    setTaskDataLoading(false)
+                }
+            } catch {
+                if (!cancelled) {
+                    setTaskDataError('Unable to load category scores')
+                    setTaskDataLoading(false)
+                }
+            }
+        }
+
+        loadTaskData(missingEntries)
+        return () => { cancelled = true }
+    }, [categoryFilterActive, filteredEntries, taskDataBySubmission])
+
+    const categoryScoredEntries = useMemo(() => {
+        if (!categoryFilterActive) return filteredEntries
+
+        const scored: LeaderboardEntry[] = []
+
+        for (const entry of filteredEntries) {
+            const tasks = taskDataBySubmission[entry.submission_id]
+            if (!tasks) continue
+            const categoryScore = calculateCategoryFilteredScore(tasks, selectedCategories)
+            if (categoryScore.percentage == null || categoryScore.count === 0) continue
+            scored.push({
+                ...entry,
+                percentage: categoryScore.percentage,
+                average_score_percentage: null,
+            })
+        }
+
+        scored.sort((a, b) => b.percentage - a.percentage)
+
+        return calculateRanksByPercentage(scored)
+    }, [categoryFilterActive, filteredEntries, selectedCategories, taskDataBySubmission])
+
+    const activeCategoryTaskCount = useMemo(() => {
+        if (!categoryFilterActive) return null
+        const counts = new Set<number>()
+        for (const entry of filteredEntries) {
+            const tasks = taskDataBySubmission[entry.submission_id]
+            if (!tasks) continue
+            const count = calculateCategoryFilteredScore(tasks, selectedCategories).count
+            if (count > 0) counts.add(count)
+        }
+        if (counts.size > 0) return Math.max(...counts)
+        return taskDataLoading ? null : 0
+    }, [categoryFilterActive, filteredEntries, selectedCategories, taskDataBySubmission, taskDataLoading])
 
     const providerColor = providerFilter
         ? PROVIDER_COLORS[providerFilter.toLowerCase()] || '#666'
@@ -153,10 +260,14 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                 scoreMode={scoreMode}
                 officialOnly={officialOnlyState}
                 openWeightsOnly={openWeightsOnly}
+                selectedCategories={selectedCategories}
+                categoryDataLoading={taskDataLoading}
+                activeCategoryTaskCount={activeCategoryTaskCount}
                 onViewChange={setView}
                 onScoreModeChange={setScoreMode}
                 onOfficialOnlyChange={setOfficialOnly}
                 onOpenWeightsOnlyChange={setOpenWeightsOnly}
+                onCategoriesChange={setSelectedCategories}
                 onClearProviderFilter={() => setProviderFilter(null)}
                 onModelSearchChange={handleModelSearchChange}
                 modelSearchValue={modelSearch}
@@ -206,15 +317,29 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                         <KiloClawAdCard />
                     </div>
                 ) : (
+                    <>
+                    {categoryFilterActive && taskDataError ? (
+                        <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                            {taskDataError}
+                        </div>
+                    ) : null}
+                    {categoryFilterActive && taskDataLoading ? (
+                        <div className="mb-4 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                            Loading category-specific scores for {filteredEntries.length} models...
+                        </div>
+                    ) : null}
                     <SimpleLeaderboard
-                        entries={filteredEntries}
+                        entries={categoryScoredEntries}
                         view={view as 'success' | 'speed' | 'cost' | 'value'}
                         scoreMode={scoreMode}
                         benchmarkVersion={currentVersion}
                         officialOnly={officialOnlyState}
+                        selectedCategories={selectedCategories}
+                        activeCategoryTaskCount={activeCategoryTaskCount}
                         onScoreModeChange={setScoreMode}
                         onProviderClick={setProviderFilter}
                     />
+                    </>
                 )}
             </main>
         </div>

--- a/components/leaderboard-view.tsx
+++ b/components/leaderboard-view.tsx
@@ -189,7 +189,9 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                 }
 
                 if (!cancelled) {
-                    setTaskDataBySubmission((current) => ({ ...current, ...loaded }))
+                    if (Object.keys(loaded).length > 0) {
+                        setTaskDataBySubmission((current) => ({ ...current, ...loaded }))
+                    }
                     setTaskDataLoading(false)
                 }
             } catch {

--- a/components/simple-leaderboard.tsx
+++ b/components/simple-leaderboard.tsx
@@ -8,7 +8,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { DEFAULT_TABLE_ROW_LIMIT } from '@/lib/constants'
 import type { LeaderboardEntry, SortMode } from '@/lib/types'
-import { PROVIDER_COLORS } from '@/lib/types'
+import { PROVIDER_COLORS, TASK_CATEGORY_BY_ID } from '@/lib/types'
 import { ShareableWrapper } from '@/components/shareable-wrapper'
 import { KiloClawAdCard } from '@/components/kiloclaw-ad-card'
 
@@ -18,6 +18,8 @@ interface SimpleLeaderboardProps {
   scoreMode: 'best' | 'average'
   benchmarkVersion?: string | null
   officialOnly: boolean
+  selectedCategories?: string[]
+  activeCategoryTaskCount?: number | null
   onScoreModeChange?: (mode: 'best' | 'average') => void
   onProviderClick?: (provider: string) => void
 }
@@ -88,6 +90,8 @@ export function SimpleLeaderboard({
   scoreMode,
   benchmarkVersion,
   officialOnly,
+  selectedCategories = [],
+  activeCategoryTaskCount,
   onScoreModeChange,
   onProviderClick,
 }: SimpleLeaderboardProps) {
@@ -95,11 +99,16 @@ export function SimpleLeaderboard({
   const [showZeroCostResults, setShowZeroCostResults] = useState(false)
   const [sortMode, setSortMode] = useState<SortMode>('quality')
   const [maxCostFilter, setMaxCostFilter] = useState<string>('')
+  const categoryFilterActive = selectedCategories.length > 0
+  const selectedCategoryLabels = selectedCategories
+    .map((cat) => TASK_CATEGORY_BY_ID[cat]?.label ?? cat.replace(/_/g, ' '))
+    .join(', ')
 
   const submissionHref = (submissionId: string) => (
     officialOnly ? `/submission/${submissionId}` : `/submission/${submissionId}?official=false`
   )
   const getSortScorePercentage = (entry: LeaderboardEntry) => {
+    if (categoryFilterActive) return entry.percentage
     if (scoreMode === 'average') {
       return entry.average_score_percentage != null
         ? entry.average_score_percentage * 100
@@ -241,6 +250,11 @@ export function SimpleLeaderboard({
           <Info className="h-3 w-3 flex-shrink-0" />
           Models without cost data are excluded. CPST is estimated from best run score (~40 tasks).
         </p>
+        {categoryFilterActive ? (
+          <p className="text-xs text-muted-foreground/80 mb-4">
+            Category filter active: value scores still use overall run score because cost is reported per full run.
+          </p>
+        ) : null}
 
         {/* Budget Filter */}
         <div className="flex items-center gap-3 mb-6 p-3 rounded-lg border border-border bg-muted/20">
@@ -501,7 +515,16 @@ export function SimpleLeaderboard({
         </div>
 
         <p className="text-sm text-muted-foreground mb-2">
-          Percentage of{' '}
+          {categoryFilterActive ? (
+            <>
+              Best-run scores recalculated from {selectedCategoryLabels}
+              {activeCategoryTaskCount != null ? ` (${activeCategoryTaskCount} tasks)` : ''}.
+            </>
+          ) : (
+            <>Percentage of{' '}</>
+          )}
+          {!categoryFilterActive ? (
+            <>
           <Link
             href="https://github.com/pinchbench/skill/tree/main/tasks"
             className="underline underline-offset-2 hover:text-foreground"
@@ -510,6 +533,8 @@ export function SimpleLeaderboard({
             tasks
           </Link> completed successfully across standardized
           OpenClaw agent tests
+            </>
+          ) : null}
         </p>
         <p className="text-xs text-muted-foreground mb-6 flex items-center gap-1.5">
           <Info className="h-3 w-3 flex-shrink-0" />
@@ -530,20 +555,22 @@ export function SimpleLeaderboard({
 
         {/* Bar Chart - hidden on mobile */}
         <ShareableWrapper
-          title="Success Rate by Model"
-          subtitle={`${displayedEntries.length} models${sortMode === 'value' ? ' • sorted by value' : ` • sorted by ${scoreMode} score`}`}
+          title={categoryFilterActive ? 'Category Score by Model' : 'Success Rate by Model'}
+          subtitle={categoryFilterActive
+            ? `${displayedEntries.length} models • ${selectedCategoryLabels}`
+            : `${displayedEntries.length} models${sortMode === 'value' ? ' • sorted by value' : ` • sorted by ${scoreMode} score`}`}
           alwaysShowButton
         >
           <div className="hidden md:block bg-card border border-border rounded-lg p-6 mb-6">
             <div className="mb-4 flex items-center gap-5 text-xs text-muted-foreground">
               <span className="inline-flex items-center gap-2">
                 <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: BEST_SCORE_COLOR }} />
-                Best Score
+                {categoryFilterActive ? 'Category Score' : 'Best Score'}
               </span>
-              <span className="inline-flex items-center gap-2">
+              {!categoryFilterActive ? <span className="inline-flex items-center gap-2">
                 <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: AVG_SCORE_COLOR }} />
                 Average Score
-              </span>
+              </span> : null}
             </div>
             <div className="space-y-3">
               {(showAllEntries ? displayedEntries.concat(nullEntries) : displayedEntries).map((entry) => {
@@ -589,7 +616,7 @@ export function SimpleLeaderboard({
                                   {bestPct.toFixed(1)}%
                                 </span>
                               </div>
-                              <div className="bg-muted rounded-full h-7 relative overflow-hidden">
+                              {!categoryFilterActive ? <div className="bg-muted rounded-full h-7 relative overflow-hidden">
                                 <div
                                   className="h-full rounded-full transition-all duration-300 group-hover:opacity-80"
                                   style={{
@@ -603,7 +630,7 @@ export function SimpleLeaderboard({
                                 >
                                   {avgPct == null ? 'N/A' : `${avgPct.toFixed(1)}%`}
                                 </span>
-                              </div>
+                              </div> : null}
                             </div>
                             <div className="w-24 text-right space-y-1.5">
                               <div>
@@ -614,14 +641,14 @@ export function SimpleLeaderboard({
                                   {bestPct.toFixed(1)}%
                                 </span>
                               </div>
-                              <div>
+                              {!categoryFilterActive ? <div>
                                 <span
                                   className="text-sm font-bold"
                                   style={{ color: AVG_SCORE_COLOR }}
                                 >
                                   {avgPct == null ? 'N/A' : `${avgPct.toFixed(1)}%`}
                                 </span>
-                              </div>
+                              </div> : null}
                             </div>
                           </div>
                         </div>
@@ -635,9 +662,9 @@ export function SimpleLeaderboard({
                         </span>
                       </p>
                       <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-                        <span className="text-muted-foreground">Best score</span>
+                        <span className="text-muted-foreground">{categoryFilterActive ? 'Category score' : 'Best score'}</span>
                         <span className="text-foreground font-medium text-right">{bestPct.toFixed(1)}%</span>
-                        {avgPct != null && (
+                        {!categoryFilterActive && avgPct != null && (
                           <>
                             <span className="text-muted-foreground">Avg score</span>
                             <span className="text-foreground font-medium text-right">{avgPct.toFixed(1)}%</span>
@@ -696,8 +723,10 @@ export function SimpleLeaderboard({
 
         {/* Simple Table */}
         <ShareableWrapper
-          title="Success Rate Rankings"
-          subtitle={`${displayedEntries.length} models • sorted by ${scoreMode} score`}
+          title={categoryFilterActive ? 'Category Score Rankings' : 'Success Rate Rankings'}
+          subtitle={categoryFilterActive
+            ? `${displayedEntries.length} models • ${selectedCategoryLabels}`
+            : `${displayedEntries.length} models • sorted by ${scoreMode} score`}
         >
           <div className="bg-card border border-border rounded-lg overflow-hidden">
             <table className="w-full">
@@ -710,16 +739,16 @@ export function SimpleLeaderboard({
                     Provider
                   </th>
                   <th className="px-2 md:px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase">
-                    <span className="md:hidden">{scoreMode === 'best' ? 'Best %' : 'Avg %'}</span>
-                    <span className="hidden md:inline">Best %</span>
+                    <span className="md:hidden">{categoryFilterActive ? 'Cat %' : scoreMode === 'best' ? 'Best %' : 'Avg %'}</span>
+                    <span className="hidden md:inline">{categoryFilterActive ? 'Category %' : 'Best %'}</span>
                   </th>
-                  <th className="hidden md:table-cell px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase">
+                  {!categoryFilterActive ? <th className="hidden md:table-cell px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase">
                     <ColumnTooltip
                       label="Avg %"
                       description="Average success rate across all runs for this model. Click any row to see the per-task scoring breakdown with individual pass/fail details."
                       benchmarkVersion={benchmarkVersion}
                     />
-                  </th>
+                  </th> : null}
                   {sortMode === 'value' && (
                     <th className="hidden md:table-cell px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase">
                       <ColumnTooltip
@@ -737,8 +766,8 @@ export function SimpleLeaderboard({
                   const avgPct = entry.average_score_percentage != null
                     ? entry.average_score_percentage * 100
                     : null
-                  const mobileScore = scoreMode === 'best' ? bestPct : avgPct
-                  const mobileScoreColor = scoreMode === 'best' ? BEST_SCORE_COLOR : AVG_SCORE_COLOR
+                  const mobileScore = categoryFilterActive || scoreMode === 'best' ? bestPct : avgPct
+                  const mobileScoreColor = categoryFilterActive || scoreMode === 'best' ? BEST_SCORE_COLOR : AVG_SCORE_COLOR
                   return (
                     <tr
                       key={entry.submission_id}
@@ -788,11 +817,11 @@ export function SimpleLeaderboard({
                           {bestPct.toFixed(1)}%
                         </span>
                       </td>
-                      <td className="hidden md:table-cell px-4 py-3 text-right">
+                      {!categoryFilterActive ? <td className="hidden md:table-cell px-4 py-3 text-right">
                         <span className="text-sm font-medium" style={{ color: AVG_SCORE_COLOR }}>
                           {avgPct == null ? 'N/A' : `${avgPct.toFixed(1)}%`}
                         </span>
-                      </td>
+                      </td> : null}
                       {sortMode === 'value' && (
                         <td className="hidden md:table-cell px-4 py-3 text-right">
                           {entry.value_score != null ? (

--- a/components/task-heatmap.tsx
+++ b/components/task-heatmap.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import type { LeaderboardEntry } from '@/lib/types'
-import { PROVIDER_COLORS, CATEGORY_ICONS } from '@/lib/types'
+import { PROVIDER_COLORS } from '@/lib/types'
 import { fetchSubmissionClient } from '@/lib/api'
 import { transformSubmission } from '@/lib/transforms'
 import { ShareableWrapper } from '@/components/shareable-wrapper'
+import { CategoryPills } from '@/components/category-pills'
+import { getCategoryMeta } from '@/lib/category-scores'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 interface TaskHeatmapProps {
@@ -137,18 +139,6 @@ export function TaskHeatmap({ entries, selectedCategories, onCategoriesChange }:
     return allTasks.filter((t) => set.has(t.category.toLowerCase()))
   }, [allTasks, selectedCategories, categoryFilterActive])
 
-  const availableCategories = useMemo(() => {
-    const seen = new Set<string>()
-    const order: string[] = []
-    for (const t of allTasks) {
-      if (!seen.has(t.category)) {
-        seen.add(t.category)
-        order.push(t.category)
-      }
-    }
-    return order
-  }, [allTasks])
-
   const modelFilteredPercentage = useMemo(() => {
     const map = new Map<string, number>()
     if (!categoryFilterActive || filteredTasks.length === 0) return map
@@ -202,14 +192,6 @@ export function TaskHeatmap({ entries, selectedCategories, onCategoriesChange }:
     if (current) groups.push({ category: current, count })
     return groups
   }, [filteredTasks])
-
-  function toggleCategory(category: string) {
-    const key = category.toLowerCase()
-    const next = selectedCategories.includes(key)
-      ? selectedCategories.filter((c) => c !== key)
-      : [...selectedCategories, key]
-    onCategoriesChange(next)
-  }
 
   if (loading) {
     return (
@@ -285,40 +267,12 @@ export function TaskHeatmap({ entries, selectedCategories, onCategoriesChange }:
         </div>
       ) : null}
 
-      {/* Category chips */}
-      <div className="flex flex-wrap items-center gap-2 mb-4">
-        <span className="text-xs text-muted-foreground shrink-0">Categories:</span>
-        <button
-          type="button"
-          onClick={() => onCategoriesChange([])}
-          className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors border ${
-            !categoryFilterActive
-              ? 'bg-primary text-primary-foreground border-primary'
-              : 'bg-secondary text-secondary-foreground border-border hover:bg-secondary/80'
-          }`}
-        >
-          All
-        </button>
-        {availableCategories.map((cat) => {
-          const active =
-            categoryFilterActive && selectedCategories.includes(cat.toLowerCase())
-          return (
-            <button
-              key={cat}
-              type="button"
-              onClick={() => toggleCategory(cat)}
-              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium transition-colors border capitalize ${
-                active
-                  ? 'bg-primary text-primary-foreground border-primary'
-                  : 'bg-secondary text-secondary-foreground border-border hover:bg-secondary/80'
-              }`}
-            >
-              <span>{CATEGORY_ICONS[cat] ?? CATEGORY_ICONS.other}</span>
-              {cat}
-            </button>
-          )
-        })}
-      </div>
+      <CategoryPills
+        selectedCategories={selectedCategories}
+        onCategoriesChange={onCategoriesChange}
+        activeTaskCount={categoryFilterActive ? filteredTasks.length : null}
+        className="mb-4"
+      />
 
       {/* Controls */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4 mb-4">
@@ -390,8 +344,8 @@ export function TaskHeatmap({ entries, selectedCategories, onCategoriesChange }:
                     colSpan={group.count}
                     className="border-b border-border px-1 py-1.5 text-center font-medium text-muted-foreground bg-muted/30"
                   >
-                    <span title={group.category} className="capitalize">
-                      {CATEGORY_ICONS[group.category] || ''} {group.category}
+                      <span title={getCategoryMeta(group.category).label}>
+                        {getCategoryMeta(group.category).icon} {getCategoryMeta(group.category).shortLabel}
                     </span>
                   </th>
                 ))}
@@ -429,7 +383,7 @@ export function TaskHeatmap({ entries, selectedCategories, onCategoriesChange }:
                       </TooltipTrigger>
                       <TooltipContent side="top" className="max-w-xs">
                         <p className="font-medium">{task.taskName}</p>
-                        <p className="text-xs text-muted-foreground capitalize">{task.category}</p>
+                        <p className="text-xs text-muted-foreground">{getCategoryMeta(task.category).label}</p>
                       </TooltipContent>
                     </Tooltip>
                   </th>

--- a/lib/category-scores.ts
+++ b/lib/category-scores.ts
@@ -1,0 +1,110 @@
+import type { LeaderboardEntry, TaskResult } from "@/lib/types";
+import { TASK_CATEGORY_BY_ID } from "@/lib/types";
+
+export interface CategoryScore {
+  category: string;
+  label: string;
+  shortLabel: string;
+  icon: string;
+  total: number;
+  max: number;
+  count: number;
+  percentage: number;
+}
+
+export interface CategoryFilteredScore {
+  total: number;
+  max: number;
+  count: number;
+  percentage: number | null;
+}
+
+export function normalizeCategoryId(category: string): string {
+  return category.trim().toLowerCase();
+}
+
+export function getCategoryMeta(category: string) {
+  const normalized = normalizeCategoryId(category);
+  return TASK_CATEGORY_BY_ID[normalized] ?? {
+    id: normalized,
+    label: normalized.replace(/_/g, " "),
+    shortLabel: normalized.replace(/_/g, " "),
+    icon: "📌",
+    description: "Benchmark tasks in this category",
+  };
+}
+
+export function aggregateCategoryScores(tasks: TaskResult[]): CategoryScore[] {
+  const scores = tasks.reduce(
+    (acc, task) => {
+      const category = normalizeCategoryId(task.category || "other");
+      if (!acc[category]) {
+        acc[category] = { total: 0, max: 0, count: 0 };
+      }
+      acc[category].total += task.score;
+      acc[category].max += task.max_score;
+      acc[category].count += 1;
+      return acc;
+    },
+    {} as Record<string, { total: number; max: number; count: number }>,
+  );
+
+  return Object.entries(scores)
+    .map(([category, score]) => {
+      const meta = getCategoryMeta(category);
+      return {
+        category,
+        label: meta.label,
+        shortLabel: meta.shortLabel,
+        icon: meta.icon,
+        total: score.total,
+        max: score.max,
+        count: score.count,
+        percentage: score.max > 0 ? (score.total / score.max) * 100 : 0,
+      };
+    })
+    .sort((a, b) => b.percentage - a.percentage || a.label.localeCompare(b.label));
+}
+
+export function calculateCategoryFilteredScore(
+  tasks: TaskResult[],
+  selectedCategories: string[],
+): CategoryFilteredScore {
+  const categorySet = new Set(selectedCategories.map(normalizeCategoryId));
+  let total = 0;
+  let max = 0;
+  let count = 0;
+
+  for (const task of tasks) {
+    if (!categorySet.has(normalizeCategoryId(task.category || "other"))) continue;
+    total += task.score;
+    max += task.max_score;
+    count += 1;
+  }
+
+  return {
+    total,
+    max,
+    count,
+    percentage: max > 0 ? (total / max) * 100 : null,
+  };
+}
+
+export function calculateRanksByPercentage(
+  entries: LeaderboardEntry[],
+): LeaderboardEntry[] {
+  let lastRank = 0;
+  let lastPercentage = Number.NaN;
+
+  return entries.map((entry, index) => {
+    if (
+      lastRank > 0 &&
+      Math.abs(entry.percentage - lastPercentage) <= 1e-6
+    ) {
+      return { ...entry, rank: lastRank };
+    }
+    lastRank = index + 1;
+    lastPercentage = entry.percentage;
+    return { ...entry, rank: lastRank };
+  });
+}

--- a/lib/task-metadata.ts
+++ b/lib/task-metadata.ts
@@ -1,14 +1,132 @@
 export const TASK_FALLBACK: Record<string, { name: string; category: string }> =
   {
-    task_00_sanity: { name: "Sanity Check", category: "validation" },
-    task_01_calendar: { name: "Calendar Event", category: "calendar" },
-    task_02_stock: { name: "Stock Research", category: "api" },
-    task_03_blog: { name: "Blog Post", category: "writing" },
-    task_04_weather: { name: "Weather Script", category: "coding" },
-    task_05_summary: { name: "Document Summary", category: "comprehension" },
-    task_06_events: { name: "Events Research", category: "research" },
-    task_07_email: { name: "Email Draft", category: "writing" },
-    task_08_memory: { name: "Memory Retrieval", category: "context" },
-    task_09_files: { name: "File Operations", category: "coding" },
-    task_10_workflow: { name: "Multi-step Workflow", category: "complex" },
+    task_00_sanity: { name: "Sanity Check", category: "core_agent" },
+    task_01_calendar: { name: "Calendar Event", category: "productivity" },
+    task_02_stock: { name: "Stock Research", category: "data_analysis" },
+    task_03_blog: { name: "Blog Post", category: "writing_content" },
+    task_04_weather: { name: "Weather Script", category: "code_devops" },
+    task_05_summary: { name: "Document Summary", category: "writing_content" },
+    task_06_events: { name: "Events Research", category: "research_knowledge" },
+    task_07_email: { name: "Email Draft", category: "productivity" },
+    task_08_memory: { name: "Memory Retrieval", category: "core_agent" },
+    task_09_files: { name: "File Operations", category: "core_agent" },
+    task_10_workflow: { name: "Multi-step Workflow", category: "core_agent" },
+
+    task_test_generation: { name: "Test Generation", category: "code_devops" },
+    task_k8s_debugging: { name: "K8s Debugging", category: "code_devops" },
+    task_cicd_pipeline_debug: { name: "CI/CD Pipeline Debug", category: "code_devops" },
+    task_dockerfile_optimization: { name: "Dockerfile Optimization", category: "code_devops" },
+    task_selector_fix: { name: "Selector Fix", category: "code_devops" },
+    task_multi_file_refactoring: { name: "Multi-file Refactoring", category: "code_devops" },
+    task_playwright_e2e: { name: "Playwright E2E", category: "code_devops" },
+    task_git_rescue_recovery: { name: "Git Rescue Recovery", category: "code_devops" },
+
+    task_spreadsheet_summary: { name: "Spreadsheet Summary", category: "data_analysis" },
+    task_financial_ratio_calculation: { name: "Financial Ratio Calculation", category: "data_analysis" },
+    task_earnings_analysis: { name: "Earnings Analysis", category: "data_analysis" },
+
+    task_humanizer: { name: "Humanizer", category: "writing_content" },
+    task_readme_generation: { name: "README Generation", category: "writing_content" },
+    task_commit_message_writer: { name: "Commit Message Writer", category: "writing_content" },
+    task_eli5_pdf_summary: { name: "ELI5 PDF Summary", category: "writing_content" },
+
+    task_todo_list_cleanup: { name: "Todo List Cleanup", category: "productivity" },
+    task_daily_summary: { name: "Daily Summary", category: "productivity" },
+    task_pdf_to_calendar: { name: "PDF to Calendar", category: "productivity" },
+
+    task_market_research: { name: "Market Research", category: "research_knowledge" },
+    task_executive_lookup: { name: "Executive Lookup", category: "research_knowledge" },
+    task_polymarket_briefing: { name: "Polymarket Briefing", category: "research_knowledge" },
+    task_contract_analysis: { name: "Contract Analysis", category: "research_knowledge" },
+    task_skill_search: { name: "Skill Search", category: "research_knowledge" },
+
+    task_access_log_anomaly: { name: "Access Log Anomaly", category: "security_ops" },
+    task_cve_security_triage: { name: "CVE Security Triage", category: "security_ops" },
+    task_gh_issue_triage: { name: "GitHub Issue Triage", category: "security_ops" },
+
+    task_openclaw_comprehension: { name: "OpenClaw Comprehension", category: "core_agent" },
+    task_second_brain: { name: "Second Brain", category: "core_agent" },
+
+    task_image_gen: { name: "Image Generation", category: "creative" },
+    task_image_identification: { name: "Image Identification", category: "creative" },
   };
+
+const LEGACY_CATEGORY_MAP: Record<string, string> = {
+  api: "data_analysis",
+  validation: "core_agent",
+  calendar: "productivity",
+  research: "research_knowledge",
+  writing: "writing_content",
+  coding: "code_devops",
+  comprehension: "core_agent",
+  context: "core_agent",
+  complex: "core_agent",
+};
+
+const TASK_CATEGORY_PATTERNS: Array<{ pattern: RegExp; category: string }> = [
+  {
+    pattern: /(test_generation|k8s|cicd|dockerfile|selector_fix|refactor|playwright|git_rescue|weather|code)/,
+    category: "code_devops",
+  },
+  {
+    pattern: /(csv|spreadsheet|financial|earnings|stock|ratio|analysis)/,
+    category: "data_analysis",
+  },
+  {
+    pattern: /(blog|humanizer|readme|commit_message|summary|eli5|writing|content)/,
+    category: "writing_content",
+  },
+  {
+    pattern: /(calendar|email|todo|daily_summary|gws|pdf_to_calendar|productivity)/,
+    category: "productivity",
+  },
+  {
+    pattern: /(market_research|executive|polymarket|contract|skill_search|research|events)/,
+    category: "research_knowledge",
+  },
+  {
+    pattern: /(access_log|cve|security|gh_issue|triage|anomaly)/,
+    category: "security_ops",
+  },
+  {
+    pattern: /(sanity|memory|files|workflow|openclaw|second_brain|comprehension|context)/,
+    category: "core_agent",
+  },
+  {
+    pattern: /(image|creative)/,
+    category: "creative",
+  },
+];
+
+export function resolveTaskCategory(
+  taskId: string,
+  category?: string | null,
+): string {
+  const normalizedCategory = category?.trim().toLowerCase();
+  if (normalizedCategory) {
+    if (LEGACY_CATEGORY_MAP[normalizedCategory]) {
+      return LEGACY_CATEGORY_MAP[normalizedCategory];
+    }
+    if (
+      [
+        "code_devops",
+        "data_analysis",
+        "writing_content",
+        "productivity",
+        "research_knowledge",
+        "security_ops",
+        "core_agent",
+        "creative",
+      ].includes(normalizedCategory)
+    ) {
+      return normalizedCategory;
+    }
+  }
+
+  const normalizedTaskId = taskId.toLowerCase();
+  for (const { pattern, category: mappedCategory } of TASK_CATEGORY_PATTERNS) {
+    if (pattern.test(normalizedTaskId)) return mappedCategory;
+  }
+
+  return normalizedCategory || "other";
+}

--- a/lib/transforms.ts
+++ b/lib/transforms.ts
@@ -6,7 +6,7 @@ import type {
   Submission,
   TaskResult,
 } from "@/lib/types";
-import { TASK_FALLBACK } from "@/lib/task-metadata";
+import { resolveTaskCategory, TASK_FALLBACK } from "@/lib/task-metadata";
 
 const EPSILON = 1e-6;
 
@@ -112,8 +112,10 @@ export function transformTaskResult(apiTask: ApiTaskResult): TaskResult {
   const fallback = TASK_FALLBACK[apiTask.task_id];
   const taskName =
     apiTask.frontmatter?.name ?? fallback?.name ?? apiTask.task_id;
-  const category =
-    apiTask.frontmatter?.category ?? fallback?.category ?? "other";
+  const category = resolveTaskCategory(
+    apiTask.task_id,
+    apiTask.frontmatter?.category ?? fallback?.category,
+  );
 
   return {
     task_id: apiTask.task_id,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,6 +20,14 @@ export interface LeaderboardEntry {
   official?: boolean;
 }
 
+export interface TaskCategory {
+  id: string;
+  label: string;
+  shortLabel: string;
+  icon: string;
+  description: string;
+}
+
 export interface TaskResult {
   task_id: string;
   task_name: string;
@@ -242,7 +250,82 @@ export interface BenchmarkVersionsResponse {
 
 export type SortMode = "quality" | "value";
 
+export const TASK_CATEGORIES: TaskCategory[] = [
+  {
+    id: "code_devops",
+    label: "Code & DevOps",
+    shortLabel: "Code",
+    icon: "🔧",
+    description: "Coding, automation, CI/CD, Kubernetes, Docker, tests, and refactors",
+  },
+  {
+    id: "data_analysis",
+    label: "Data & Analysis",
+    shortLabel: "Data",
+    icon: "📊",
+    description: "CSV, spreadsheet, market, earnings, and financial analysis tasks",
+  },
+  {
+    id: "writing_content",
+    label: "Writing & Content",
+    shortLabel: "Writing",
+    icon: "✍️",
+    description: "Blog posts, summaries, README generation, and content rewriting",
+  },
+  {
+    id: "productivity",
+    label: "Productivity",
+    shortLabel: "Productivity",
+    icon: "📅",
+    description: "Calendar, email, todo, daily summary, and workspace organization tasks",
+  },
+  {
+    id: "research_knowledge",
+    label: "Research & Knowledge",
+    shortLabel: "Research",
+    icon: "🔍",
+    description: "Market research, lookups, briefings, contract analysis, and skill search",
+  },
+  {
+    id: "security_ops",
+    label: "Security & Ops",
+    shortLabel: "Security",
+    icon: "🛡️",
+    description: "Security triage, anomaly detection, GitHub issue triage, and ops tasks",
+  },
+  {
+    id: "core_agent",
+    label: "Core Agent",
+    shortLabel: "Agent",
+    icon: "🤖",
+    description: "Sanity, memory, files, workflow, and OpenClaw comprehension tasks",
+  },
+  {
+    id: "creative",
+    label: "Creative",
+    shortLabel: "Creative",
+    icon: "🎨",
+    description: "Image generation, image identification, and creative tasks",
+  },
+]
+
+export const TASK_CATEGORY_BY_ID = TASK_CATEGORIES.reduce(
+  (acc, category) => {
+    acc[category.id] = category
+    return acc
+  },
+  {} as Record<string, TaskCategory>,
+)
+
 export const CATEGORY_ICONS: Record<string, string> = {
+  code_devops: "🔧",
+  data_analysis: "📊",
+  writing_content: "✍️",
+  productivity: "📅",
+  research_knowledge: "🔍",
+  security_ops: "🛡️",
+  core_agent: "🤖",
+  creative: "🎨",
   api: "🔌",
   validation: "✅",
   calendar: "📅",


### PR DESCRIPTION
- Introduced TASK_CATEGORIES with icons and descriptions for 8 task categories
- Added CategoryPills component for category selection UI
- Added category-scores.ts with aggregateCategoryScores, calculateCategoryFilteredScore, and calculateRanksByPercentage utilities
- Updated task-metadata.ts with new category mappings and resolveTaskCategory function
- Enhanced model page to show category breakdown for best submission
- Enhanced leaderboard view to support category filtering with live task data loading
- Updated submission page to use aggregateCategoryScores
- Updated simple-leaderboard and task-heatmap to support category filtering
- Maintained backward compatibility with existing category handling

### Motivation

Issue #86 requested that PinchBench 2.0’s expanded task set (55+ tasks) be organized by user-relevant categories. The goal is to let users filter models by use case (e.g. “best model for DevOps” or “best for data analysis”), show per-model category breakdowns, and lay groundwork for category-specific landing pages.

Previously, all tasks were weighted equally and there was no way to isolate domain-specific performance.

### Solution

Implemented full front‑end category support against the existing task‑level data path, without requiring backend changes:

- **Category definitions** (`lib/types.ts`): Introduced `TASK_CATEGORIES` and `TASK_CATEGORY_BY_ID` for the eight requested categories with icons and human labels.
- **Shared scoring utilities** (`lib/category-scores.ts`): `aggregateCategoryScores`, `calculateCategoryFilteredScore`, and `calculateRanksByPercentage` to normalize calculations across components.
- **Category normalization** (`lib/task-metadata.ts`, `lib/transforms.ts`):
  - Added legacy category mapping and comprehensive PinchBench 2.0 task manifest entries.
  - Implemented `resolveTaskCategory` with task‑id pattern matching so existing benchmark data classifies into the new categories automatically.
- **Category filter UI** (`components/category-pills.tsx`): Reusable pill component with icons, shared between the header and heatmap.
- **Main filter bar** (`components/leaderboard-header.tsx`): Integrated category pills alongside the existing provider/weight filters.
- **Leaderboard orchestration** (`components/leaderboard-view.tsx`):
  - Reads/writes `categories` URL param.
  - When categories are selected, fetches best‑submission task details for visible models (cached by submission ID, batched 5 at a time).
  - Recalculates leaderboard `percentage` and ranks from selected category tasks only.
- **Success view UI** (`components/simple-leaderboard.tsx`): Adapts titles, subtitles, bar chart, and table to show “category score” instead of global score when filtering.
- **Task heatmap** (`components/task-heatmap.tsx`): Reused the new category pills; migrated from old hardcoded categories to normalized labels/icons.
- **Model page** (`app/model/[...slug]/page.tsx`): Fetches the model’s best submission and renders a “Best Run Category Breakdown” grid of cards.
- **Submission detail** (`app/submission/[id]/page.tsx`): Uses shared aggregation helper for a consistent breakdown.

### Testing / Verification

- **Build**: `bun run build` passed cleanly.
- **Browser** (Playwright):
  - Loaded the home page; confirmed the new category filter bar appears with all eight categories + “All”.
  - Selected “Code”; URL updated to `/?categories=code_devops`. Showed “3 tasks selected”, copy switched to category‑scoring mode, and rankings recalculated.
  - Switched to Graphs → Task Heatmap; heatmap preserved category state and displayed filtered tasks.
  - Clicked through to a model page; confirmed “Best Run Category Breakdown” renders normalized category icons/percentages for the best run.
  - Verified no console errors during the final pass (network requests to API returned 200).
- **Type checking**: Project‑level `tsc` shows pre‑existing unrelated errors (test file imports, mock fixtures). Those are outside the scope of this change.

### Notes

- **Performance**: Category filtering triggers one `/submissions/:id` fetch per visible model, batched 5‑at‑a‑time and cached client‑side. This matches the existing heatmap behavior; acceptable for MVP but may warrant a backend aggregate endpoint later.
- **Data shape**: Category scores use the best‑submission task data. Average category scores are unavailable from the current API, so the UI clearly labels everything as “best‑run” when filtering.
- **Breaking changes**: None. Fully additive; URL param `categories` is optional.
- **Dependencies**: None added; uses existing `recharts`, `shadcn/ui`, Tailwind CSS.
- **Related issue**: Closes #86.