### PR TITLE
feat(model-detail): redesign model detail page with comprehensive analytics tabs

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from 'next/og'
 import { fetchLeaderboard } from '@/lib/api'
 import { calculateRanks, transformLeaderboardEntry } from '@/lib/transforms'
+import { getScoreColorHex } from '@/lib/scores'
 
 export const runtime = 'edge'
 
@@ -20,12 +21,6 @@ const COLORS = {
   yellow: '#eab308',
   red: '#ef4444',
   primary: '#3b82f6',
-}
-
-function getScoreColor(pct: number): string {
-  if (pct >= 85) return COLORS.green
-  if (pct >= 70) return COLORS.yellow
-  return COLORS.red
 }
 
 const PROVIDER_COLORS: Record<string, string> = {
@@ -237,7 +232,7 @@ export async function GET(request: Request) {
                         style={{
                           width: `${entry.percentage}%`,
                           height: '100%',
-                          backgroundColor: getScoreColor(entry.percentage),
+                          backgroundColor: getScoreColorHex(entry.percentage),
                           borderRadius: '10px',
                         }}
                       />
@@ -250,7 +245,7 @@ export async function GET(request: Request) {
                   style={{
                     fontSize: '15px',
                     fontWeight: 700,
-                    color: view === 'success' ? getScoreColor(entry.percentage) : COLORS.text,
+                    color: view === 'success' ? getScoreColorHex(entry.percentage) : COLORS.text,
                     width: '80px',
                     textAlign: 'right',
                   }}

--- a/app/model/[...slug]/page.tsx
+++ b/app/model/[...slug]/page.tsx
@@ -3,11 +3,18 @@ import Link from 'next/link'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
-import { ArrowLeft, BarChart3, Clock, DollarSign, Activity } from 'lucide-react'
-import { PROVIDER_COLORS } from '@/lib/types'
-import { fetchModelSubmissions } from '@/lib/api'
-import { formatDistanceToNow } from 'date-fns'
+import { ArrowLeft, Activity } from 'lucide-react'
+import { PROVIDER_COLORS, type TaskResult } from '@/lib/types'
+import { fetchModelSubmissions, fetchSubmission } from '@/lib/api'
+import { getModelBadgeStatuses } from '@/lib/badges'
+import { ModelVarianceStats } from '@/components/model-variance-stats'
+import { ModelBadgeShowcase } from '@/components/model-badge-showcase'
+import { ModelTaskBreakdown } from '@/components/model-task-breakdown'
+import { ModelCostEfficiency } from '@/components/model-cost-efficiency'
+import { ModelRunHistory } from '@/components/model-run-history'
 import { ModelScoreTrend } from '@/components/model-score-trend'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { getScoreColorClass } from '@/lib/scores'
 
 interface ModelPageProps {
   params: Promise<{ slug: string[] }>
@@ -25,10 +32,11 @@ export default async function ModelPage({ params, searchParams }: ModelPageProps
 
   const provider = slug[0]
   const modelName = slug.slice(1).join('/')
+  const modelString = `${provider}/${modelName}`
 
-  let data
+  let modelData
   try {
-    data = await fetchModelSubmissions(modelName, { officialOnly })
+    modelData = await fetchModelSubmissions(modelName, { officialOnly })
   } catch (error) {
     return (
       <div className="min-h-screen bg-background p-6">
@@ -36,18 +44,18 @@ export default async function ModelPage({ params, searchParams }: ModelPageProps
           <h2 className="text-xl font-bold mb-4">Error loading model data</h2>
           <p className="text-muted-foreground">Could not fetch submissions for {modelName}.</p>
           <Link href="/">
-             <Button className="mt-4">Back to Leaderboard</Button>
+            <Button className="mt-4">Back to Leaderboard</Button>
           </Link>
         </Card>
       </div>
     )
   }
 
-  if (!data || data.submissions.length === 0) {
+  if (!modelData || modelData.submissions.length === 0) {
     notFound()
   }
 
-  const submissions = data.submissions.sort((a, b) => 
+  const submissions = [...modelData.submissions].sort((a, b) =>
     new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
   )
 
@@ -56,7 +64,6 @@ export default async function ModelPage({ params, searchParams }: ModelPageProps
   const avgScore = scores.reduce((a, b) => a + b, 0) / scores.length
   const sortedScores = [...scores].sort((a, b) => a - b)
   const medianScore = sortedScores[Math.floor(sortedScores.length / 2)]
-
   const avgCost = submissions.reduce((a, b) => a + (b.total_cost_usd || 0), 0) / submissions.length
   const avgSpeed = submissions.reduce((a, b) => a + (b.total_execution_time_seconds || 0), 0) / submissions.length
 
@@ -66,6 +73,53 @@ export default async function ModelPage({ params, searchParams }: ModelPageProps
     timestamp: s.timestamp,
     score: s.score_percentage * 100
   }))
+
+  // Find submissions with most complete task data
+  async function fetchBestTaskData(submissionIds: string[]): Promise<Awaited<ReturnType<typeof fetchSubmission>> | null> {
+    for (let i = 0; i < Math.min(submissionIds.length, 3); i++) {
+      try {
+        const detail = await fetchSubmission(submissionIds[i])
+        if (detail?.submission?.tasks && detail.submission.tasks.length >= 5) {
+          return detail
+        }
+      } catch {
+        // Continue to next submission
+      }
+    }
+    // Return whatever we got from the first attempt (even if incomplete)
+    try {
+      return await fetchSubmission(submissionIds[0])
+    } catch {
+      return null
+    }
+  }
+
+  // Get submission IDs sorted by score (best first), then by recency
+  const sortedByScore = [...submissions].sort((a, b) => {
+    if (a.is_best && !b.is_best) return -1
+    if (!a.is_best && b.is_best) return 1
+    return (b.score_percentage ?? 0) - (a.score_percentage ?? 0)
+  })
+
+  const bestSubmissionDetail = await fetchBestTaskData(sortedByScore.map(s => s.id))
+
+  const badgeStatuses = await getModelBadgeStatuses(modelName).catch(() => [])
+
+  let tasks: TaskResult[] = []
+  if (bestSubmissionDetail?.submission?.tasks) {
+    tasks = bestSubmissionDetail.submission.tasks.map(t => ({
+      task_id: t.task_id,
+      task_name: t.frontmatter?.name ?? t.task_id,
+      category: t.frontmatter?.category ?? 'other',
+      score: t.score,
+      max_score: t.max_score,
+      breakdown: t.breakdown,
+      grading_type: t.grading_type,
+      timed_out: t.timed_out,
+      notes: t.notes,
+      execution_time_seconds: t.execution_time_seconds,
+    }))
+  }
 
   return (
     <div className="min-h-screen bg-background">
@@ -83,9 +137,9 @@ export default async function ModelPage({ params, searchParams }: ModelPageProps
           <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
             <div>
               <div className="flex items-center gap-3 mb-2">
-                <code className="text-3xl font-mono font-bold text-foreground">
+                <h1 className="text-3xl font-mono font-bold text-foreground">
                   {modelName}
-                </code>
+                </h1>
                 <Badge
                   variant="outline"
                   className="text-sm"
@@ -113,83 +167,78 @@ export default async function ModelPage({ params, searchParams }: ModelPageProps
       </header>
 
       <main className="max-w-7xl mx-auto px-6 py-8 space-y-8">
-        {/* Stats Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-          <Card className="p-4 flex flex-col items-center justify-center text-center">
-            <BarChart3 className="h-5 w-5 text-primary mb-2" />
-            <span className="text-sm text-muted-foreground">Best Score</span>
-            <span className="text-2xl font-bold">{bestScore.toFixed(1)}%</span>
-          </Card>
-          <Card className="p-4 flex flex-col items-center justify-center text-center">
-            <Activity className="h-5 w-5 text-blue-500 mb-2" />
-            <span className="text-sm text-muted-foreground">Average Score</span>
-            <span className="text-2xl font-bold">{avgScore.toFixed(1)}%</span>
-          </Card>
-          <Card className="p-4 flex flex-col items-center justify-center text-center">
-            <Activity className="h-5 w-5 text-purple-500 mb-2" />
-            <span className="text-sm text-muted-foreground">Median Score</span>
-            <span className="text-2xl font-bold">{medianScore.toFixed(1)}%</span>
-          </Card>
-          <Card className="p-4 flex flex-col items-center justify-center text-center">
-            <DollarSign className="h-5 w-5 text-green-500 mb-2" />
-            <span className="text-sm text-muted-foreground">Avg Cost</span>
-            <span className="text-2xl font-bold">${avgCost.toFixed(4)}</span>
-          </Card>
-          <Card className="p-4 flex flex-col items-center justify-center text-center">
-            <Clock className="h-5 w-5 text-orange-500 mb-2" />
-            <span className="text-sm text-muted-foreground">Avg Speed</span>
-            <span className="text-2xl font-bold">{avgSpeed.toFixed(1)}s</span>
-          </Card>
-        </div>
+        {badgeStatuses && badgeStatuses.length > 0 && (
+          <section aria-label="Badge Showcase">
+            <ModelBadgeShowcase model={modelString} badges={badgeStatuses} />
+          </section>
+        )}
 
-        {/* Score Trend Chart */}
-        <Card className="p-6">
-          <h3 className="text-lg font-semibold mb-4">Score Trend Over Time</h3>
-          <ModelScoreTrend data={trendData} />
-        </Card>
+        <Tabs defaultValue="overview" className="w-full">
+          <TabsList className="grid w-full grid-cols-4 mb-8">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="tasks">Tasks</TabsTrigger>
+            <TabsTrigger value="cost">Cost</TabsTrigger>
+            <TabsTrigger value="runs">Runs</TabsTrigger>
+          </TabsList>
 
-        {/* Submissions Table */}
-        <div className="space-y-4">
-          <h3 className="text-lg font-semibold">Submission History</h3>
-          <div className="rounded-md border border-border overflow-hidden">
-            <table className="w-full text-sm">
-              <thead className="bg-muted/50 border-b border-border">
-                <tr>
-                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">Date</th>
-                  <th className="px-4 py-3 text-right font-medium text-muted-foreground">Score</th>
-                  <th className="px-4 py-3 text-right font-medium text-muted-foreground">Speed</th>
-                  <th className="px-4 py-3 text-right font-medium text-muted-foreground">Cost</th>
-                  <th className="px-4 py-3 text-right font-medium text-muted-foreground">Actions</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {submissions.map((s) => (
-                  <tr key={s.id} className="hover:bg-muted/30 transition-colors">
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {formatDistanceToNow(new Date(s.timestamp), { addSuffix: true })}
-                    </td>
-                    <td className="px-4 py-3 text-right font-medium">
-                      {(s.score_percentage * 100).toFixed(1)}%
-                    </td>
-                    <td className="px-4 py-3 text-right text-muted-foreground">
-                      {s.total_execution_time_seconds ? `${s.total_execution_time_seconds.toFixed(1)}s` : '-'}
-                    </td>
-                    <td className="px-4 py-3 text-right text-muted-foreground">
-                      {s.total_cost_usd ? `$${s.total_cost_usd.toFixed(4)}` : '-'}
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <Link href={`/submission/${s.id}${officialOnly ? '' : '?official=false'}`}>
-                        <Button variant="outline" size="sm">
-                          View Details
-                        </Button>
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
+          <TabsContent value="overview" className="space-y-8">
+            <section aria-label="Performance Statistics">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+                <Card className="p-4 flex flex-col items-center justify-center text-center">
+                  <span className="text-sm text-muted-foreground">Best Score</span>
+                  <span className={`text-2xl font-bold ${getScoreColorClass(bestScore)}`}>{bestScore.toFixed(1)}%</span>
+                </Card>
+                <Card className="p-4 flex flex-col items-center justify-center text-center">
+                  <span className="text-sm text-muted-foreground">Average Score</span>
+                  <span className={`text-2xl font-bold ${getScoreColorClass(avgScore)}`}>{avgScore.toFixed(1)}%</span>
+                </Card>
+                <Card className="p-4 flex flex-col items-center justify-center text-center">
+                  <span className="text-sm text-muted-foreground">Median Score</span>
+                  <span className={`text-2xl font-bold ${getScoreColorClass(medianScore)}`}>{medianScore.toFixed(1)}%</span>
+                </Card>
+                <Card className="p-4 flex flex-col items-center justify-center text-center">
+                  <span className="text-sm text-muted-foreground">Avg Cost</span>
+                  <span className="text-2xl font-bold text-muted-foreground">${avgCost.toFixed(4)}</span>
+                </Card>
+                <Card className="p-4 flex flex-col items-center justify-center text-center">
+                  <span className="text-sm text-muted-foreground">Avg Speed</span>
+                  <span className="text-2xl font-bold text-muted-foreground">{avgSpeed.toFixed(1)}s</span>
+                </Card>
+              </div>
+            </section>
+
+            <ModelVarianceStats submissions={submissions} />
+
+            <Card className="p-6">
+              <h2 className="text-lg font-semibold mb-4">Score Trend Over Time</h2>
+              <ModelScoreTrend data={trendData} />
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="tasks" className="space-y-6">
+            {tasks.length > 0 ? (
+              <ModelTaskBreakdown tasks={tasks} />
+            ) : (
+              <Card className="p-6">
+                <p className="text-muted-foreground text-center">
+                  Task breakdown data is not available for this model.
+                </p>
+              </Card>
+            )}
+          </TabsContent>
+
+          <TabsContent value="cost" className="space-y-6">
+            <ModelCostEfficiency submissions={submissions} />
+          </TabsContent>
+
+          <TabsContent value="runs" className="space-y-6">
+            <ModelRunHistory
+              submissions={submissions}
+              benchmarkVersions={modelData.benchmark_versions}
+              officialOnly={officialOnly}
+            />
+          </TabsContent>
+        </Tabs>
       </main>
     </div>
   )

--- a/components/model-badge-showcase.tsx
+++ b/components/model-badge-showcase.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { BadgeEmbedCard } from '@/components/badge-embed-card'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import type { ModelBadgeStatus } from '@/lib/badges'
+
+interface ModelBadgeShowcaseProps {
+  model: string
+  badges: ModelBadgeStatus[]
+}
+
+export function ModelBadgeShowcase({ model, badges }: ModelBadgeShowcaseProps) {
+  const earnedBadges = badges.filter((badge) => badge.awarded)
+  const unearnedBadges = badges.filter((badge) => !badge.awarded)
+
+  return (
+    <div className="space-y-6">
+      <BadgeEmbedCard model={model} badges={badges} />
+
+      <Card className="bg-card border-border">
+        <CardHeader>
+          <CardTitle>Badge Showcase</CardTitle>
+          <CardDescription>
+            Embeddable badges showing success rate, speed, cost, and value metrics across daily, weekly, and monthly windows.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2">
+            {earnedBadges.map((badge) => (
+              <Badge
+                key={`${badge.metric}-${badge.period}`}
+                variant="default"
+              >
+                {badge.shortLabel} ✓
+              </Badge>
+            ))}
+          </div>
+          {unearnedBadges.length > 0 && (
+            <div className="mt-4">
+              <p className="text-sm text-muted-foreground mb-2">Not yet earned</p>
+              <div className="flex flex-wrap gap-2">
+                {unearnedBadges.map((badge) => (
+                  <Badge
+                    key={`unearned-${badge.metric}-${badge.period}`}
+                    variant="secondary"
+                    className="opacity-50 grayscale"
+                  >
+                    {badge.shortLabel}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/model-cost-efficiency.test.tsx
+++ b/components/model-cost-efficiency.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test'
+import { calculateValueScore, getValueScoreInterpretation } from './model-cost-efficiency'
+
+describe('calculateValueScore', () => {
+  test('calculates value score correctly: (avgScore * 100) / avgCost', () => {
+    expect(calculateValueScore(0.85, 0.02)).toBe(4250)
+  })
+
+  test('returns null when avgScore is null', () => {
+    expect(calculateValueScore(null, 0.02)).toBeNull()
+  })
+
+  test('returns null when avgCost is null', () => {
+    expect(calculateValueScore(0.85, null)).toBeNull()
+  })
+
+  test('returns null when avgCost is zero', () => {
+    expect(calculateValueScore(0.85, 0)).toBeNull()
+  })
+
+  test('returns null when avgCost is negative', () => {
+    expect(calculateValueScore(0.85, -0.01)).toBeNull()
+  })
+
+  test('handles high score with low cost = high value', () => {
+    const result = calculateValueScore(0.95, 0.01)
+    expect(result).toBe(9500)
+  })
+
+  test('handles low score with high cost = low value', () => {
+    const result = calculateValueScore(0.50, 10)
+    expect(result).toBe(5)
+  })
+
+  test('handles moderate score and cost', () => {
+    const result = calculateValueScore(0.80, 0.04)
+    expect(result).toBe(2000)
+  })
+
+  test('score percentage as whole number (0-100 scale)', () => {
+    const result = calculateValueScore(85, 0.10)
+    expect(result).toBe(85000)
+  })
+
+  test('very small cost produces large value score', () => {
+    const result = calculateValueScore(0.90, 0.001)
+    expect(result).toBe(90000)
+  })
+
+  test('equal score and cost', () => {
+    const result = calculateValueScore(0.50, 0.50)
+    expect(result).toBe(100)
+  })
+
+  test('both null returns null', () => {
+    expect(calculateValueScore(null, null)).toBeNull()
+  })
+})
+
+describe('getValueScoreInterpretation', () => {
+  test('returns "Insufficient data" for null', () => {
+    expect(getValueScoreInterpretation(null)).toBe('Insufficient data')
+  })
+
+  test('returns "Excellent value" for score >= 500', () => {
+    expect(getValueScoreInterpretation(500)).toBe('Excellent value')
+    expect(getValueScoreInterpretation(1000)).toBe('Excellent value')
+  })
+
+  test('returns "Good value" for score >= 200 and < 500', () => {
+    expect(getValueScoreInterpretation(200)).toBe('Good value')
+    expect(getValueScoreInterpretation(499)).toBe('Good value')
+  })
+
+  test('returns "Moderate value" for score >= 100 and < 200', () => {
+    expect(getValueScoreInterpretation(100)).toBe('Moderate value')
+    expect(getValueScoreInterpretation(199)).toBe('Moderate value')
+  })
+
+  test('returns "Low value" for score < 100', () => {
+    expect(getValueScoreInterpretation(99)).toBe('Low value')
+    expect(getValueScoreInterpretation(0)).toBe('Low value')
+  })
+
+  test('boundary: 500 is Excellent', () => {
+    expect(getValueScoreInterpretation(500)).toBe('Excellent value')
+  })
+
+  test('boundary: 499 is Good', () => {
+    expect(getValueScoreInterpretation(499)).toBe('Good value')
+  })
+
+  test('boundary: 200 is Good', () => {
+    expect(getValueScoreInterpretation(200)).toBe('Good value')
+  })
+
+  test('boundary: 199 is Moderate', () => {
+    expect(getValueScoreInterpretation(199)).toBe('Moderate value')
+  })
+
+  test('boundary: 100 is Moderate', () => {
+    expect(getValueScoreInterpretation(100)).toBe('Moderate value')
+  })
+
+  test('boundary: 99 is Low', () => {
+    expect(getValueScoreInterpretation(99)).toBe('Low value')
+  })
+
+  test('handles negative values as Low', () => {
+    expect(getValueScoreInterpretation(-50)).toBe('Low value')
+  })
+})

--- a/components/model-cost-efficiency.tsx
+++ b/components/model-cost-efficiency.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+import { DollarSign, Clock, Calculator, Info } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { ApiModelSubmissionItem } from '@/lib/types'
+import { fmtCurrency, fmtDuration } from '@/lib/format'
+
+interface ModelCostEfficiencyProps {
+  submissions: ApiModelSubmissionItem[]
+}
+
+export function calculateValueScore(avgScore: number | null, avgCost: number | null): number | null {
+  return avgScore != null && avgCost != null && avgCost > 0
+    ? (avgScore * 100) / avgCost
+    : null
+}
+
+export function getValueScoreInterpretation(valueScore: number | null): string {
+  if (valueScore == null) return 'Insufficient data'
+  if (valueScore >= 500) return 'Excellent value'
+  if (valueScore >= 200) return 'Good value'
+  if (valueScore >= 100) return 'Moderate value'
+  return 'Low value'
+}
+
+export function ModelCostEfficiency({ submissions }: ModelCostEfficiencyProps) {
+  const costs = submissions
+    .map(s => s.total_cost_usd)
+    .filter((c): c is number => c != null && c >= 0)
+
+  const times = submissions
+    .map(s => s.total_execution_time_seconds)
+    .filter((t): t is number => t != null && t > 0)
+
+  const scores = submissions.map(s => s.score_percentage).filter(s => s > 0)
+
+  // Detect if API is missing cost/time data entirely
+  const hasCostData = costs.length > 0
+  const hasTimeData = times.length > 0
+  const hasAnyData = hasCostData || hasTimeData
+
+  const minCost = hasCostData ? Math.min(...costs) : null
+  const maxCost = hasCostData ? Math.max(...costs) : null
+  const avgCost = hasCostData ? costs.reduce((a, b) => a + b, 0) / costs.length : null
+
+  const minTime = hasTimeData ? Math.min(...times) : null
+  const maxTime = hasTimeData ? Math.max(...times) : null
+  const avgTime = hasTimeData ? times.reduce((a, b) => a + b, 0) / times.length : null
+
+  const avgScore = scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : null
+
+  const valueScore = calculateValueScore(avgScore, avgCost)
+
+  const costSubmissions = submissions
+    .filter(s => s.total_cost_usd != null && s.total_cost_usd >= 0)
+  const avgCostTime = costSubmissions.length > 0
+    ? costSubmissions.reduce((sum, s) => sum + (s.total_execution_time_seconds ?? 0), 0) / costSubmissions.length
+    : null
+  const costPerSecond = avgCostTime != null && avgCostTime > 0
+    ? costSubmissions.reduce((sum, s) => sum + (s.total_cost_usd ?? 0), 0) / avgCostTime
+    : null
+
+  const allCostsZero = costs.length > 0 && costs.every(c => c === 0)
+
+  if (!hasAnyData) {
+    return (
+      <Card className="p-6">
+        <div className="text-center space-y-3">
+          <DollarSign className="h-12 w-12 mx-auto text-muted-foreground/40" />
+          <h3 className="text-lg font-semibold">Cost &amp; Efficiency data unavailable</h3>
+          <p className="text-sm text-muted-foreground max-w-md mx-auto">
+            The API does not currently include per-run cost and execution time in the model submissions list.
+            This data is available on the leaderboard endpoint and will be added to model submissions in a future API update.
+          </p>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Cost per Run</CardTitle>
+          <DollarSign className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          {hasCostData ? (
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span className="text-sm text-muted-foreground">Min</span>
+                <span className="text-sm font-medium">{fmtCurrency(minCost!)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-muted-foreground">Max</span>
+                <span className="text-sm font-medium">{fmtCurrency(maxCost!)}</span>
+              </div>
+              <div className="flex justify-between border-t pt-2">
+                <span className="text-sm font-medium">Average</span>
+                <span className="text-sm font-bold">{fmtCurrency(avgCost!)}</span>
+              </div>
+              {allCostsZero && (
+                <p className="text-xs text-muted-foreground italic">All runs were free tier</p>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground text-center py-4">Cost data not available</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Execution Time</CardTitle>
+          <Clock className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          {hasTimeData ? (
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span className="text-sm text-muted-foreground">Min</span>
+                <span className="text-sm font-medium">{fmtDuration(minTime!)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-muted-foreground">Max</span>
+                <span className="text-sm font-medium">{fmtDuration(maxTime!)}</span>
+              </div>
+              <div className="flex justify-between border-t pt-2">
+                <span className="text-sm font-medium">Average</span>
+                <span className="text-sm font-bold">{fmtDuration(avgTime!)}</span>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground text-center py-4">Time data not available</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Speed</CardTitle>
+          <DollarSign className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          {hasTimeData && hasCostData ? (
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span className="text-sm text-muted-foreground">Avg Time</span>
+                <span className="text-sm font-medium">{fmtDuration(avgTime!)}</span>
+              </div>
+              <div className="flex justify-between border-t pt-2">
+                <span className="text-sm font-medium">Cost/sec</span>
+                <span className="text-sm font-bold">
+                  {costPerSecond != null ? fmtCurrency(costPerSecond, 4) : 'N/A'}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground text-center py-4">Requires both cost &amp; time data</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="md:col-span-2 lg:col-span-3">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <div className="flex items-center gap-2">
+            <CardTitle className="text-sm font-medium">Value Score</CardTitle>
+            <div className="group relative">
+              <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block w-64 p-3 bg-popover border rounded-md shadow-md text-sm text-popover-foreground z-50">
+                Value Score measures how much score you get per dollar spent. Higher is better.
+                <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-popover" />
+              </div>
+            </div>
+          </div>
+          <Calculator className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          {hasCostData ? (
+            <div className="flex items-center gap-6">
+              <div>
+                <div className="text-3xl font-bold">
+                  {valueScore != null ? valueScore.toFixed(2) : 'N/A'}
+                </div>
+                <p className="text-sm text-muted-foreground mt-1">
+                  (score &times; 100) / avg cost
+                </p>
+              </div>
+              <div className="h-12 w-px bg-border" />
+              <div className="space-y-1">
+                <div className="flex justify-between gap-8">
+                  <span className="text-sm text-muted-foreground">Avg Score</span>
+                  <span className="text-sm font-medium">{avgScore != null ? `${(avgScore * 100).toFixed(1)}%` : 'N/A'}</span>
+                </div>
+                <div className="flex justify-between gap-8">
+                  <span className="text-sm text-muted-foreground">Avg Cost</span>
+                  <span className="text-sm font-medium">{fmtCurrency(avgCost!)}</span>
+                </div>
+                {allCostsZero && (
+                  <div className="flex justify-between gap-8 pt-1">
+                    <span className="text-sm text-muted-foreground">Note</span>
+                    <span className="text-xs text-muted-foreground italic">All runs were free tier</span>
+                  </div>
+                )}
+                <div className="flex justify-between gap-8 pt-1 border-t">
+                  <span className="text-sm font-medium">Interpretation</span>
+                  <span className="text-sm font-medium">
+                    {getValueScoreInterpretation(valueScore)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center gap-6">
+              <div>
+                <div className="text-3xl font-bold text-muted-foreground">N/A</div>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Requires cost data
+                </p>
+              </div>
+              <div className="h-12 w-px bg-border" />
+              <div className="space-y-1">
+                <div className="flex justify-between gap-8">
+                  <span className="text-sm text-muted-foreground">Avg Score</span>
+                  <span className="text-sm font-medium">{avgScore != null ? `${(avgScore * 100).toFixed(1)}%` : 'N/A'}</span>
+                </div>
+                <div className="flex justify-between gap-8 pt-1 border-t">
+                  <span className="text-sm font-medium">Interpretation</span>
+                  <span className="text-sm font-medium text-muted-foreground">Cost data unavailable</span>
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/model-run-history.test.tsx
+++ b/components/model-run-history.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  filterSubmissionsByVersion,
+  sortSubmissionsByTimestamp,
+  ModelRunHistory,
+} from './model-run-history'
+import type { ApiModelSubmissionItem } from '@/lib/types'
+
+// Note: getScoreColorClass is tested in lib/scores.test.ts
+// Note: fmtSpeed and fmtCurrency are tested in lib/format.test.ts
+
+function submission(overrides: Partial<ApiModelSubmissionItem>): ApiModelSubmissionItem {
+  return {
+    id: overrides.id ?? 'run_123',
+    model: overrides.model ?? 'test-model',
+    provider: overrides.provider ?? 'test',
+    score_percentage: overrides.score_percentage ?? 0.8,
+    total_score: overrides.total_score ?? 32,
+    max_score: overrides.max_score ?? 40,
+    total_execution_time_seconds: overrides.total_execution_time_seconds ?? 100,
+    total_cost_usd: overrides.total_cost_usd ?? 0.05,
+    timestamp: overrides.timestamp ?? '2026-03-28T12:00:00.000Z',
+    created_at: overrides.created_at ?? '2026-03-28T12:00:00.000Z',
+    client_version: overrides.client_version ?? null,
+    openclaw_version: overrides.openclaw_version ?? null,
+    benchmark_version: overrides.benchmark_version ?? 'bench-123',
+    claimed: overrides.claimed ?? 1,
+    official: overrides.official ?? true,
+    is_best: overrides.is_best ?? false,
+  }
+}
+
+describe('filterSubmissionsByVersion', () => {
+  test('returns all submissions when version is "all"', () => {
+    const subs = [
+      submission({ id: 'run_v1_abc123', timestamp: '2026-03-28T12:00:00.000Z' }),
+      submission({ id: 'run_v2_def456', timestamp: '2026-03-28T13:00:00.000Z' }),
+    ]
+    const result = filterSubmissionsByVersion(subs, 'all')
+    expect(result).toHaveLength(2)
+  })
+
+  test('filters by version in ID suffix', () => {
+    const subs = [
+      submission({ id: 'model_v1_abc123', timestamp: '2026-03-28T12:00:00.000Z' }),
+      submission({ id: 'model_v2_def456', timestamp: '2026-03-28T13:00:00.000Z' }),
+      submission({ id: 'model_v3_abc123', timestamp: '2026-03-28T14:00:00.000Z' }),
+    ]
+    const result = filterSubmissionsByVersion(subs, 'abc123')
+    expect(result).toHaveLength(2)
+    expect(result.every(s => s.id.includes('abc123'))).toBe(true)
+  })
+
+  test('returns empty array when no matches', () => {
+    const subs = [
+      submission({ id: 'model_v1_abc123' }),
+      submission({ id: 'model_v2_def456' }),
+    ]
+    const result = filterSubmissionsByVersion(subs, 'xyz789')
+    expect(result).toHaveLength(0)
+  })
+
+  test('handles empty submissions array', () => {
+    const result = filterSubmissionsByVersion([], 'abc123')
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe('sortSubmissionsByTimestamp', () => {
+  test('sorts by timestamp newest first', () => {
+    const subs = [
+      submission({ id: 'run1', timestamp: '2026-03-28T10:00:00.000Z' }),
+      submission({ id: 'run2', timestamp: '2026-03-28T14:00:00.000Z' }),
+      submission({ id: 'run3', timestamp: '2026-03-28T12:00:00.000Z' }),
+    ]
+    const result = sortSubmissionsByTimestamp(subs)
+    expect(result[0]?.id).toBe('run2')
+    expect(result[1]?.id).toBe('run3')
+    expect(result[2]?.id).toBe('run1')
+  })
+
+  test('handles single submission', () => {
+    const subs = [submission({ id: 'run1' })]
+    const result = sortSubmissionsByTimestamp(subs)
+    expect(result).toHaveLength(1)
+  })
+
+  test('handles empty array', () => {
+    const result = sortSubmissionsByTimestamp([])
+    expect(result).toHaveLength(0)
+  })
+
+  test('does not mutate original array', () => {
+    const subs = [
+      submission({ id: 'run1', timestamp: '2026-03-28T10:00:00.000Z' }),
+      submission({ id: 'run2', timestamp: '2026-03-28T14:00:00.000Z' }),
+    ]
+    const original = [...subs]
+    sortSubmissionsByTimestamp(subs)
+    expect(subs[0]?.id).toBe(original[0]?.id)
+  })
+})
+
+describe('ModelRunHistory component', () => {
+  test('exports the component', () => {
+    expect(ModelRunHistory).toBeDefined()
+    expect(typeof ModelRunHistory).toBe('function')
+  })
+})

--- a/components/model-run-history.tsx
+++ b/components/model-run-history.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { formatDistanceToNow } from 'date-fns'
+import Link from 'next/link'
+import type { ApiModelSubmissionItem } from '@/lib/types'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { getScoreColorClass } from '@/lib/scores'
+import { fmtSpeed, fmtCurrency } from '@/lib/format'
+
+interface ModelRunHistoryProps {
+  submissions: ApiModelSubmissionItem[]
+  benchmarkVersions: string[]
+  officialOnly: boolean
+}
+
+export function filterSubmissionsByVersion(
+  submissions: ApiModelSubmissionItem[],
+  selectedVersion: string
+): ApiModelSubmissionItem[] {
+  if (selectedVersion === 'all') return submissions
+  return submissions.filter(s => {
+    const parts = s.id.split('_')
+    const suffix = parts[parts.length - 1]
+    return suffix.startsWith(selectedVersion)
+  })
+}
+
+export function sortSubmissionsByTimestamp(
+  submissions: ApiModelSubmissionItem[]
+): ApiModelSubmissionItem[] {
+  return [...submissions].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+}
+
+export function ModelRunHistory({ submissions, benchmarkVersions, officialOnly }: ModelRunHistoryProps) {
+  const [selectedVersion, setSelectedVersion] = useState<string>('all')
+
+  const filteredSubmissions = useMemo(() => {
+    return filterSubmissionsByVersion(submissions, selectedVersion)
+  }, [submissions, selectedVersion])
+
+  const sortedSubmissions = useMemo(() => {
+    return sortSubmissionsByTimestamp(filteredSubmissions)
+  }, [filteredSubmissions])
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <CardTitle className="text-lg font-semibold">Run History</CardTitle>
+        <Select value={selectedVersion} onValueChange={setSelectedVersion}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="All versions" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All versions</SelectItem>
+            {benchmarkVersions.map(version => (
+              <SelectItem key={version} value={version}>
+                {version.slice(0, 7)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border/50">
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">Date</th>
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">Score</th>
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">Speed</th>
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">Cost</th>
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">Benchmark Version</th>
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedSubmissions.map((submission) => {
+                const date = new Date(submission.timestamp)
+                const dateStr = formatDistanceToNow(date) + ' ago'
+                const version = submission.id.split('_').pop()?.slice(0, 7) || 'Unknown'
+                const linkHref = officialOnly
+                  ? `/submission/${submission.id}`
+                  : `/submission/${submission.id}?official=false`
+
+                return (
+                  <tr key={submission.id} className="border-b border-border/30 hover:bg-muted/30 transition-colors">
+                    <td className="py-3 px-4 whitespace-nowrap">{dateStr}</td>
+                    <td className="py-3 px-4">
+                      <div className="flex items-center gap-2">
+                        <span className={`font-semibold ${getScoreColorClass(submission.score_percentage)}`}>
+                          {(submission.score_percentage * 100).toFixed(1)}%
+                        </span>
+                        {submission.is_best && (
+                          <Badge variant="default" className="bg-green-600 text-xs px-1.5 py-0">
+                            Best
+                          </Badge>
+                        )}
+                      </div>
+                    </td>
+                    <td className="py-3 px-4 text-muted-foreground">
+                      {fmtSpeed(submission.total_execution_time_seconds)}
+                    </td>
+                    <td className="py-3 px-4 text-muted-foreground">
+                      {submission.total_cost_usd != null ? fmtCurrency(submission.total_cost_usd, 2) : 'N/A'}
+                    </td>
+                    <td className="py-3 px-4 font-mono text-xs text-muted-foreground">
+                      {version}
+                    </td>
+                    <td className="py-3 px-4">
+                      <Link href={linkHref}>
+                        <Button variant="outline" size="sm" className="text-xs h-7">
+                          View
+                        </Button>
+                      </Link>
+                    </td>
+                  </tr>
+                )
+              })}
+              {sortedSubmissions.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="py-8 text-center text-muted-foreground">
+                    No runs found for the selected version
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/model-run-history.tsx
+++ b/components/model-run-history.tsx
@@ -97,7 +97,7 @@ export function ModelRunHistory({ submissions, benchmarkVersions, officialOnly }
                     <td className="py-3 px-4 whitespace-nowrap">{dateStr}</td>
                     <td className="py-3 px-4">
                       <div className="flex items-center gap-2">
-                        <span className={`font-semibold ${getScoreColorClass(submission.score_percentage)}`}>
+                        <span className={`font-semibold ${getScoreColorClass(submission.score_percentage * 100)}`}>
                           {(submission.score_percentage * 100).toFixed(1)}%
                         </span>
                         {submission.is_best && (

--- a/components/model-task-breakdown.test.tsx
+++ b/components/model-task-breakdown.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+import { getComparisonIndicator } from './model-task-breakdown'
+
+describe('getComparisonIndicator', () => {
+  test('returns null when no average score provided', () => {
+    expect(getComparisonIndicator(90, 100)).toBeNull()
+  })
+
+  test('returns "Above average" when task score is > 5% above average', () => {
+    const result = getComparisonIndicator(90, 100, 80)
+    expect(result).not.toBeNull()
+    expect(result?.label).toBe('Above average')
+    expect(result?.icon).toBe('↑')
+    expect(result?.color).toBe('text-green-500')
+    expect(result?.bg).toBe('bg-green-500/10')
+    expect(result?.border).toBe('border-green-500/20')
+  })
+
+  test('returns "Average" when task score is within 5% of average', () => {
+    const result = getComparisonIndicator(75, 100, 73)
+    expect(result).not.toBeNull()
+    expect(result?.label).toBe('Average')
+    expect(result?.icon).toBe('→')
+    expect(result?.color).toBe('text-yellow-500')
+    expect(result?.bg).toBe('bg-yellow-500/10')
+    expect(result?.border).toBe('border-yellow-500/20')
+  })
+
+  test('returns "Below average" when task score is > 5% below average', () => {
+    const result = getComparisonIndicator(60, 100, 70)
+    expect(result).not.toBeNull()
+    expect(result?.label).toBe('Below average')
+    expect(result?.icon).toBe('↓')
+    expect(result?.color).toBe('text-red-500')
+    expect(result?.bg).toBe('bg-red-500/10')
+    expect(result?.border).toBe('border-red-500/20')
+  })
+
+  test('handles exact 5% difference as Average', () => {
+    const result = getComparisonIndicator(75, 100, 70)
+    expect(result?.label).toBe('Average')
+  })
+
+  test('handles exact -5% difference as Average', () => {
+    const result = getComparisonIndicator(65, 100, 70)
+    expect(result?.label).toBe('Average')
+  })
+
+  test('handles scores above 100%', () => {
+    const result = getComparisonIndicator(110, 100, 90)
+    expect(result?.label).toBe('Above average')
+  })
+
+  test('handles zero scores', () => {
+    const result = getComparisonIndicator(0, 100, 50)
+    expect(result?.label).toBe('Below average')
+  })
+
+  test('perfect score vs lower average', () => {
+    const result = getComparisonIndicator(100, 100, 80)
+    expect(result?.label).toBe('Above average')
+  })
+
+  test('task score 85%, avg 79% => Above average (diff = 6%)', () => {
+    const result = getComparisonIndicator(85, 100, 79)
+    expect(result?.label).toBe('Above average')
+  })
+
+  test('task score 84%, avg 80% => Average (diff = 4%)', () => {
+    const result = getComparisonIndicator(84, 100, 80)
+    expect(result?.label).toBe('Average')
+  })
+
+  test('task score 76%, avg 82% => Below average (diff = -6%)', () => {
+    const result = getComparisonIndicator(76, 100, 82)
+    expect(result?.label).toBe('Below average')
+  })
+
+  test('task score 77%, avg 82% => Average (diff = -5%)', () => {
+    const result = getComparisonIndicator(77, 100, 82)
+    expect(result?.label).toBe('Average')
+  })
+
+  test('uses maxScore to calculate percentage correctly', () => {
+    const result = getComparisonIndicator(45, 50, 80)
+    expect(result?.label).toBe('Above average')
+  })
+
+  test('same score as average returns Average', () => {
+    const result = getComparisonIndicator(80, 100, 80)
+    expect(result?.label).toBe('Average')
+  })
+})

--- a/components/model-task-breakdown.tsx
+++ b/components/model-task-breakdown.tsx
@@ -1,0 +1,306 @@
+'use client'
+
+import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ColoredProgress } from '@/components/ui/colored-progress'
+import { ChevronDown, ChevronRight, CheckCircle, AlertTriangle, XCircle } from 'lucide-react'
+import type { TaskResult } from '@/lib/types'
+import { CATEGORY_ICONS } from '@/lib/types'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { getScoreColorFromRaw, getScoreColorClass, SCORE_THRESHOLDS } from '@/lib/scores'
+
+interface ModelTaskBreakdownProps {
+  tasks: TaskResult[]
+  averageTaskScores?: Record<string, number>
+}
+
+const getScoreIcon = (score: number, maxScore: number, timedOut: boolean): React.ReactElement => {
+  if (timedOut) return <XCircle className="h-5 w-5 text-red-500" />
+  const percentage = (score / maxScore) * 100
+  if (percentage >= SCORE_THRESHOLDS.EXCELLENT) return <CheckCircle className="h-5 w-5 text-green-500" />
+  if (percentage >= SCORE_THRESHOLDS.GOOD) return <AlertTriangle className="h-5 w-5 text-yellow-500" />
+  return <XCircle className="h-5 w-5 text-red-500" />
+}
+
+const getGradingBadgeVariant = (
+  type: 'automated' | 'llm_judge' | 'hybrid'
+) => {
+  switch (type) {
+    case 'automated':
+      return 'default'
+    case 'llm_judge':
+      return 'secondary'
+    case 'hybrid':
+      return 'outline'
+  }
+}
+
+type ComparisonResult = {
+  label: string
+  icon: string
+  color: string
+  bg: string
+  border: string
+} | null
+
+export const getComparisonIndicator = (
+  taskScore: number,
+  maxScore: number,
+  averageScore?: number
+): ComparisonResult => {
+  if (averageScore === undefined) return null
+
+  const taskPercentage = (taskScore / maxScore) * 100
+  const diff = taskPercentage - averageScore
+
+  if (diff > 5) {
+    return {
+      label: 'Above average',
+      icon: '↑',
+      color: 'text-green-500',
+      bg: 'bg-green-500/10',
+      border: 'border-green-500/20',
+    }
+  }
+  if (diff < -5) {
+    return {
+      label: 'Below average',
+      icon: '↓',
+      color: 'text-red-500',
+      bg: 'bg-red-500/10',
+      border: 'border-red-500/20',
+    }
+  }
+  return {
+    label: 'Average',
+    icon: '→',
+    color: 'text-yellow-500',
+    bg: 'bg-yellow-500/10',
+    border: 'border-yellow-500/20',
+  }
+}
+
+export function ModelTaskBreakdown({
+  tasks,
+  averageTaskScores,
+}: ModelTaskBreakdownProps) {
+  const [openTasks, setOpenTasks] = useState<Set<string>>(new Set())
+
+  const toggleTask = (taskId: string) => {
+    const newOpenTasks = new Set(openTasks)
+    if (newOpenTasks.has(taskId)) {
+      newOpenTasks.delete(taskId)
+    } else {
+      newOpenTasks.add(taskId)
+    }
+    setOpenTasks(newOpenTasks)
+  }
+
+  const excellingCount = tasks.filter((t) => {
+    const pct = (t.score / t.max_score) * 100
+    return pct >= SCORE_THRESHOLDS.EXCELLENT
+  }).length
+
+  const strugglingCount = tasks.filter((t) => {
+    const pct = (t.score / t.max_score) * 100
+    return pct < SCORE_THRESHOLDS.GOOD
+  }).length
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">Task Performance Summary</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-3 gap-4">
+            <div className="text-center">
+              <div className="text-2xl font-bold text-green-500">
+                {excellingCount}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                Tasks excelling (≥{SCORE_THRESHOLDS.EXCELLENT}%)
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-red-500">
+                {strugglingCount}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                Tasks struggling (&lt;{SCORE_THRESHOLDS.GOOD}%)
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-foreground">
+                {tasks.length}
+              </div>
+              <div className="text-xs text-muted-foreground">Total tasks</div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-2">
+        {tasks.map((task) => {
+          const percentage = (task.score / task.max_score) * 100
+          const isOpen = openTasks.has(task.task_id)
+          const avgScore = averageTaskScores?.[task.task_id]
+          const comparison = getComparisonIndicator(
+            task.score,
+            task.max_score,
+            avgScore
+          )
+
+          return (
+            <Collapsible
+              key={task.task_id}
+              open={isOpen}
+              onOpenChange={() => toggleTask(task.task_id)}
+            >
+              <div className="rounded-lg border border-border bg-card hover:bg-muted/30 transition-colors">
+                <CollapsibleTrigger className="w-full">
+                  <div className="p-4 flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-3 min-w-0 flex-1">
+                      <div className="flex-shrink-0">
+                        {getScoreIcon(
+                          task.score,
+                          task.max_score,
+                          task.timed_out
+                        )}
+                      </div>
+                      <div className="text-left min-w-0 flex-1">
+                        <div className="flex items-center gap-2 flex-wrap mb-1">
+                          <h4 className="font-semibold text-foreground">
+                            {task.task_name}
+                          </h4>
+                          <Badge variant="outline" className="text-xs">
+                            {CATEGORY_ICONS[task.category]} {task.category}
+                          </Badge>
+                          <Badge
+                            variant={getGradingBadgeVariant(task.grading_type)}
+                            className="text-xs"
+                          >
+                            {task.grading_type.replace('_', ' ')}
+                          </Badge>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <span
+                            className={`text-sm font-bold ${getScoreColorFromRaw(task.score, task.max_score)}`}
+                          >
+                            {task.score.toFixed(2)} /{' '}
+                            {task.max_score.toFixed(2)}
+                          </span>
+                          <div className="flex-1 max-w-xs">
+                            <ColoredProgress
+                              value={percentage}
+                              className="h-1.5"
+                            />
+                          </div>
+                          <span
+                            className={`text-xs font-medium ${getScoreColorFromRaw(task.score, task.max_score)}`}
+                          >
+                            {percentage.toFixed(0)}%
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      {comparison && (
+                        <Badge
+                          variant="outline"
+                          className={`text-xs ${comparison.color} ${comparison.bg} ${comparison.border}`}
+                        >
+                          {comparison.icon} {comparison.label}
+                        </Badge>
+                      )}
+                      {isOpen ? (
+                        <ChevronDown className="h-5 w-5 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="h-5 w-5 text-muted-foreground" />
+                      )}
+                    </div>
+                  </div>
+                </CollapsibleTrigger>
+
+                <CollapsibleContent>
+                  <div className="border-t border-border px-4 py-4">
+                    {avgScore !== undefined && (
+                      <div className="mb-4 p-3 rounded bg-muted/50 border border-border">
+                        <div className="flex items-center justify-between text-sm">
+                          <span className="text-muted-foreground">
+                            Leaderboard Average
+                          </span>
+                          <div className="flex items-center gap-3">
+                            <div className="w-24">
+                              <ColoredProgress
+                                value={avgScore}
+                                className="h-1.5"
+                              />
+                            </div>
+                            <span
+                              className={`font-mono font-medium ${getScoreColorClass(avgScore)}`}
+                            >
+                              {avgScore.toFixed(0)}%
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                    <h5 className="text-sm font-semibold text-foreground mb-3">
+                      Criterion Breakdown
+                    </h5>
+                    <div className="space-y-2">
+                      {Object.entries(task.breakdown).map(([key, value]) => (
+                        <div
+                          key={key}
+                          className="flex items-center justify-between gap-4 text-sm"
+                        >
+                          <span className="text-muted-foreground capitalize">
+                            {key.replace(/_/g, ' ')}
+                          </span>
+                          <div className="flex items-center gap-2">
+                            <div className="w-24">
+                              <ColoredProgress
+                                value={value * 100}
+                                className="h-1.5"
+                              />
+                            </div>
+                            <span
+                              className={`font-mono font-medium w-12 text-right ${getScoreColorFromRaw(value, 1)}`}
+                            >
+                              {value.toFixed(2)}
+                            </span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                    {task.timed_out && (
+                      <div className="mt-3 p-2 rounded bg-destructive/10 border border-destructive/20">
+                        <p className="text-xs text-destructive font-medium">
+                          ⏱️ Task exceeded timeout limit
+                        </p>
+                      </div>
+                    )}
+                    {task.notes && (
+                      <div className="mt-3 p-2 rounded bg-muted/50 border border-border">
+                        <p className="text-xs text-muted-foreground">
+                          <span className="font-semibold">Note:</span>{' '}
+                          {task.notes}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </CollapsibleContent>
+              </div>
+            </Collapsible>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/model-variance-stats.test.tsx
+++ b/components/model-variance-stats.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+import { ModelVarianceStats } from './model-variance-stats'
+import type { ApiModelSubmissionItem } from '@/lib/types'
+
+// Note: computeStats, getScoreColorHex, fmtNum, fmtCurrency, fmtDuration
+// are tested in lib/scores.test.ts and lib/format.test.ts respectively.
+
+describe('ModelVarianceStats component', () => {
+  test('exports the component', () => {
+    expect(ModelVarianceStats).toBeDefined()
+    expect(typeof ModelVarianceStats).toBe('function')
+  })
+
+  test('returns null for empty submissions', () => {
+    const result = ModelVarianceStats({ submissions: [] })
+    expect(result).toBeNull()
+  })
+
+  test('computes correct stats for sample data', () => {
+    const submissions: ApiModelSubmissionItem[] = [
+      { id: '1', score_percentage: 0.8, total_score: 32, max_score: 40, timestamp: '2026-01-01', is_best: false, total_cost_usd: 0.01, total_execution_time_seconds: 60 },
+      { id: '2', score_percentage: 0.9, total_score: 36, max_score: 40, timestamp: '2026-01-02', is_best: true, total_cost_usd: 0.02, total_execution_time_seconds: 120 },
+    ]
+    // Component renders successfully with valid data
+    expect(ModelVarianceStats({ submissions })).not.toBeNull()
+  })
+
+  test('handles missing optional fields', () => {
+    const submissions: ApiModelSubmissionItem[] = [
+      { id: '1', score_percentage: 0.85, total_score: 34, max_score: 40, timestamp: '2026-01-01', is_best: true },
+    ]
+    expect(ModelVarianceStats({ submissions })).not.toBeNull()
+  })
+})

--- a/components/model-variance-stats.tsx
+++ b/components/model-variance-stats.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { Card } from '@/components/ui/card'
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import type { ApiModelSubmissionItem } from '@/lib/types'
+import { getScoreColorHex, computeStats } from '@/lib/scores'
+import { fmtNum, fmtCurrency, fmtDuration } from '@/lib/format'
+
+interface StatRowProps {
+  label: string
+  min: string
+  max: string
+  avg: string
+  median?: string
+  stddev?: string
+}
+
+function StatRow({ label, min, max, avg, median, stddev }: StatRowProps) {
+  return (
+    <div className="grid grid-cols-5 gap-2 py-2 border-b border-border last:border-b-0 text-sm">
+      <div className="text-muted-foreground font-medium">{label}</div>
+      <div>{min}</div>
+      <div>{max}</div>
+      <div>{avg}</div>
+      <div className="flex gap-3">
+        {median !== undefined && <span>{median}</span>}
+        {stddev !== undefined && <span className="text-muted-foreground">±{stddev}</span>}
+      </div>
+    </div>
+  )
+}
+
+export function ModelVarianceStats({ submissions }: { submissions: ApiModelSubmissionItem[] }) {
+  if (submissions.length === 0) return null
+
+  const scores = submissions.map(s => s.score_percentage * 100)
+  const costs = submissions
+    .map(s => s.total_cost_usd)
+    .filter((c): c is number => c != null && c > 0)
+  const times = submissions
+    .map(s => s.total_execution_time_seconds)
+    .filter((t): t is number => t != null && t > 0)
+
+  const scoreStats = computeStats(scores)
+  const costStats = computeStats(costs)
+  const timeStats = computeStats(times)
+
+  const bestData = [
+    { name: 'Best', value: scoreStats?.max ?? 0, color: getScoreColorHex(scoreStats?.max ?? 0) },
+    { name: 'Average', value: scoreStats?.avg ?? 0, color: getScoreColorHex(scoreStats?.avg ?? 0) },
+    { name: 'Median', value: scoreStats?.median ?? 0, color: getScoreColorHex(scoreStats?.median ?? 0) },
+  ]
+
+  return (
+    <Card className="p-4 bg-card border-border">
+      <h3 className="text-lg font-semibold mb-3">Run Variance Statistics</h3>
+
+      <div className="mb-4">
+        <div className="grid grid-cols-5 gap-2 py-2 border-b border-border text-sm text-muted-foreground">
+          <div>Metric</div>
+          <div>Min</div>
+          <div>Max</div>
+          <div>Average</div>
+          <div>Median / StdDev</div>
+        </div>
+        {scoreStats && (
+          <StatRow
+            label="Score"
+            min={`${fmtNum(scoreStats.min, 1)}%`}
+            max={`${fmtNum(scoreStats.max, 1)}%`}
+            avg={`${fmtNum(scoreStats.avg, 1)}%`}
+            median={`${fmtNum(scoreStats.median, 1)}%`}
+            stddev={fmtNum(scoreStats.stddev, 1)}
+          />
+        )}
+        <StatRow
+          label="Cost"
+          min={costStats ? fmtCurrency(costStats.min) : 'N/A'}
+          max={costStats ? fmtCurrency(costStats.max) : 'N/A'}
+          avg={costStats ? fmtCurrency(costStats.avg) : 'N/A'}
+        />
+        <StatRow
+          label="Speed"
+          min={timeStats ? fmtDuration(timeStats.min) : 'N/A'}
+          max={timeStats ? fmtDuration(timeStats.max) : 'N/A'}
+          avg={timeStats ? fmtDuration(timeStats.avg) : 'N/A'}
+        />
+      </div>
+
+      <div className="mt-4">
+        <h4 className="text-sm font-medium text-muted-foreground mb-2">Score Comparison</h4>
+        <ResponsiveContainer width="100%" height={120}>
+          <BarChart data={bestData} layout="vertical" margin={{ left: 10, right: 30 }}>
+            <XAxis type="number" domain={[0, 100]} tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }} />
+            <YAxis type="category" dataKey="name" tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }} width={60} />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: 'hsl(var(--background))',
+                borderColor: 'hsl(var(--border))',
+                color: 'hsl(var(--foreground))',
+              }}
+              formatter={(value: number) => [`${fmtNum(value, 1)}%`, 'Score']}
+            />
+            <Bar dataKey="value" radius={[0, 4, 4, 0]} barSize={24}>
+              {bestData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.color} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </Card>
+  )
+}

--- a/lib/format.test.ts
+++ b/lib/format.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  fmtNum,
+  fmtCurrency,
+  fmtDuration,
+  fmtSpeed,
+  fmtCost,
+} from './format'
+
+describe('fmtNum', () => {
+  test('formats to 2 decimals by default', () => {
+    expect(fmtNum(3.14159)).toBe('3.14')
+  })
+
+  test('formats to specified decimals', () => {
+    expect(fmtNum(3.14159, 3)).toBe('3.142')
+  })
+
+  test('formats to 0 decimals', () => {
+    expect(fmtNum(42.7, 0)).toBe('43')
+  })
+
+  test('pads with zeros', () => {
+    expect(fmtNum(5)).toBe('5.00')
+  })
+})
+
+describe('fmtCurrency', () => {
+  test('formats with dollar sign and 2 decimals', () => {
+    expect(fmtCurrency(1.5)).toBe('$1.50')
+  })
+
+  test('formats zero', () => {
+    expect(fmtCurrency(0)).toBe('$0.00')
+  })
+
+  test('custom decimals', () => {
+    expect(fmtCurrency(0.00123, 4)).toBe('$0.0012')
+  })
+
+  test('handles null cost via caller', () => {
+    const cost: number | null = null
+    const result = cost != null ? fmtCurrency(cost, 2) : 'N/A'
+    expect(result).toBe('N/A')
+  })
+})
+
+describe('fmtDuration', () => {
+  test('formats seconds under 60', () => {
+    expect(fmtDuration(30)).toBe('30s')
+  })
+
+  test('formats minutes and seconds', () => {
+    expect(fmtDuration(90)).toBe('1m 30s')
+  })
+
+  test('formats exact minutes', () => {
+    expect(fmtDuration(120)).toBe('2m 0s')
+  })
+
+  test('rounds seconds', () => {
+    expect(fmtDuration(61.7)).toBe('1m 2s')
+  })
+
+  test('normalizes 60 seconds to next minute', () => {
+    expect(fmtDuration(119.9)).toBe('2m 0s')
+    expect(fmtDuration(59.9)).toBe('60s')
+  })
+})
+
+describe('fmtSpeed', () => {
+  test('returns N/A for null', () => {
+    expect(fmtSpeed(null)).toBe('N/A')
+  })
+
+  test('returns N/A for undefined', () => {
+    expect(fmtSpeed(undefined)).toBe('N/A')
+  })
+
+  test('formats seconds under 60 with 1 decimal', () => {
+    expect(fmtSpeed(30.5)).toBe('30.5s')
+  })
+
+  test('formats minutes and seconds', () => {
+    expect(fmtSpeed(90.3)).toBe('1m 30s')
+  })
+})
+
+describe('fmtCost', () => {
+  test('returns N/A for null', () => {
+    expect(fmtCost(null)).toBe('N/A')
+  })
+
+  test('formats with 4 decimals', () => {
+    expect(fmtCost(0.0012)).toBe('$0.0012')
+  })
+
+  test('formats zero', () => {
+    expect(fmtCost(0)).toBe('$0.0000')
+  })
+})

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,36 @@
+/** Format a number to fixed decimal places */
+export function fmtNum(n: number, decimals = 2): string {
+  return n.toFixed(decimals)
+}
+
+/** Format a number as a USD currency string (e.g., $1.50) */
+export function fmtCurrency(value: number, decimals = 2): string {
+  return `$${value.toFixed(decimals)}`
+}
+
+/** Format seconds into a human-readable duration (e.g., "1m 30s", "45s") */
+export function fmtDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  let mins = Math.floor(seconds / 60)
+  let secs = Math.round(seconds % 60)
+  if (secs === 60) {
+    mins += 1
+    secs = 0
+  }
+  return `${mins}m ${secs}s`
+}
+
+/** Format a speed value (seconds) with one decimal, or return N/A */
+export function fmtSpeed(seconds: number | null | undefined): string {
+  if (seconds == null) return 'N/A'
+  if (seconds < 60) return `${seconds.toFixed(1)}s`
+  const mins = Math.floor(seconds / 60)
+  const secs = (seconds % 60).toFixed(0)
+  return `${mins}m ${secs}s`
+}
+
+/** Format a cost value with 4 decimals (for small API costs), or return N/A */
+export function fmtCost(cost: number | null | undefined): string {
+  if (cost == null) return 'N/A'
+  return `$${cost.toFixed(4)}`
+}

--- a/lib/scores.test.ts
+++ b/lib/scores.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  SCORE_THRESHOLDS,
+  getScoreColorHex,
+  getScoreColorClass,
+  getScoreBgClass,
+  getScoreLabel,
+  computeStats,
+} from './scores'
+
+describe('SCORE_THRESHOLDS', () => {
+  test('EXCELLENT is 85', () => {
+    expect(SCORE_THRESHOLDS.EXCELLENT).toBe(85)
+  })
+
+  test('GOOD is 70', () => {
+    expect(SCORE_THRESHOLDS.GOOD).toBe(70)
+  })
+})
+
+describe('getScoreColorHex', () => {
+  test('returns green for >= 85', () => {
+    expect(getScoreColorHex(85)).toBe('#22c55e')
+    expect(getScoreColorHex(100)).toBe('#22c55e')
+  })
+
+  test('returns yellow for >= 70 and < 85', () => {
+    expect(getScoreColorHex(70)).toBe('#f59e0b')
+    expect(getScoreColorHex(84)).toBe('#f59e0b')
+  })
+
+  test('returns red for < 70', () => {
+    expect(getScoreColorHex(69)).toBe('#ef4444')
+    expect(getScoreColorHex(0)).toBe('#ef4444')
+  })
+})
+
+describe('getScoreColorClass', () => {
+  test('returns Tailwind green class for >= 85', () => {
+    expect(getScoreColorClass(85)).toBe('text-green-500')
+  })
+
+  test('returns Tailwind yellow class for >= 70 and < 85', () => {
+    expect(getScoreColorClass(70)).toBe('text-yellow-500')
+  })
+
+  test('returns Tailwind red class for < 70', () => {
+    expect(getScoreColorClass(69)).toBe('text-red-500')
+  })
+})
+
+describe('getScoreBgClass', () => {
+  test('returns bg-green-500 for >= 85', () => {
+    expect(getScoreBgClass(85)).toBe('bg-green-500')
+  })
+
+  test('returns bg-yellow-500 for >= 70 and < 85', () => {
+    expect(getScoreBgClass(70)).toBe('bg-yellow-500')
+  })
+
+  test('returns bg-red-500 for < 70', () => {
+    expect(getScoreBgClass(69)).toBe('bg-red-500')
+  })
+})
+
+describe('getScoreLabel', () => {
+  test('returns Excellent for >= 85', () => {
+    expect(getScoreLabel(85)).toBe('Excellent')
+  })
+
+  test('returns Good for >= 70 and < 85', () => {
+    expect(getScoreLabel(70)).toBe('Good')
+  })
+
+  test('returns Needs Improvement for < 70', () => {
+    expect(getScoreLabel(69)).toBe('Needs Improvement')
+  })
+})
+
+describe('computeStats', () => {
+  test('returns null for empty array', () => {
+    expect(computeStats([])).toBeNull()
+  })
+
+  test('computes stats for [10, 20, 30, 40, 50]', () => {
+    const stats = computeStats([10, 20, 30, 40, 50])
+    expect(stats).not.toBeNull()
+    expect(stats!.min).toBe(10)
+    expect(stats!.max).toBe(50)
+    expect(stats!.avg).toBe(30)
+    expect(stats!.median).toBe(30)
+    expect(stats!.stddev).toBeCloseTo(14.14, 2)
+  })
+
+  test('computes median for even-length array', () => {
+    const stats = computeStats([10, 20, 30, 40])
+    expect(stats!.median).toBe(25)
+  })
+
+  test('works with unsorted input', () => {
+    const stats = computeStats([50, 10, 30, 20, 40])
+    expect(stats!.min).toBe(10)
+    expect(stats!.max).toBe(50)
+    expect(stats!.avg).toBe(30)
+  })
+
+  test('returns zero stddev for identical values', () => {
+    const stats = computeStats([5, 5, 5])
+    expect(stats!.stddev).toBe(0)
+  })
+
+  test('single element array', () => {
+    const stats = computeStats([42])
+    expect(stats!.min).toBe(42)
+    expect(stats!.max).toBe(42)
+    expect(stats!.avg).toBe(42)
+    expect(stats!.median).toBe(42)
+    expect(stats!.stddev).toBe(0)
+  })
+})

--- a/lib/scores.ts
+++ b/lib/scores.ts
@@ -1,0 +1,67 @@
+/** Score thresholds used consistently across the app */
+export const SCORE_THRESHOLDS = {
+  EXCELLENT: 85,
+  GOOD: 70,
+} as const
+
+/** Hex color for score display (used in charts/SVG/OG images) */
+export function getScoreColorHex(pct: number): string {
+  if (pct >= SCORE_THRESHOLDS.EXCELLENT) return '#22c55e'
+  if (pct >= SCORE_THRESHOLDS.GOOD) return '#f59e0b'
+  return '#ef4444'
+}
+
+/** Get Tailwind color class from raw score/maxScore (e.g. 0.85/1.0 → 85%) */
+export function getScoreColorFromRaw(score: number, maxScore: number): string {
+  if (maxScore <= 0) return getScoreColorClass(0)
+  return getScoreColorClass((score / maxScore) * 100)
+}
+
+/** Tailwind CSS class for score text color */
+export function getScoreColorClass(pct: number): string {
+  if (pct >= SCORE_THRESHOLDS.EXCELLENT) return 'text-green-500'
+  if (pct >= SCORE_THRESHOLDS.GOOD) return 'text-yellow-500'
+  return 'text-red-500'
+}
+
+/** Tailwind CSS class for score background color (bg-* variant) */
+export function getScoreBgClass(pct: number): string {
+  if (pct >= SCORE_THRESHOLDS.EXCELLENT) return 'bg-green-500'
+  if (pct >= SCORE_THRESHOLDS.GOOD) return 'bg-yellow-500'
+  return 'bg-red-500'
+}
+
+/** Determine score quality label */
+export function getScoreLabel(pct: number): string {
+  if (pct >= SCORE_THRESHOLDS.EXCELLENT) return 'Excellent'
+  if (pct >= SCORE_THRESHOLDS.GOOD) return 'Good'
+  return 'Needs Improvement'
+}
+
+/** Compute statistics for an array of numbers */
+export interface StatsResult {
+  min: number
+  max: number
+  avg: number
+  median: number
+  stddev: number
+}
+
+export function computeStats(values: number[]): StatsResult | null {
+  if (values.length === 0) return null
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const min = sorted[0]
+  const max = sorted[sorted.length - 1]
+  const avg = values.reduce((a, b) => a + b, 0) / values.length
+  const mid = Math.floor(sorted.length / 2)
+  const median =
+    sorted.length % 2 !== 0
+      ? sorted[mid]
+      : (sorted[mid - 1] + sorted[mid]) / 2
+  const variance =
+    values.reduce((sum, v) => sum + (v - avg) ** 2, 0) / values.length
+  const stddev = Math.sqrt(variance)
+
+  return { min, max, avg, median, stddev }
+}


### PR DESCRIPTION
# Redesign Model Detail Page with Badges and Expanded Information

Closes #76

## Summary

Complete redesign of the model detail page (`/model/[provider]/[model]`) to incorporate badge showcases, run variance statistics, task-level breakdowns, cost & efficiency metrics, and a tabbed navigation layout. Adds shared utility libraries for score formatting and number formatting, with comprehensive unit tests.

## Changes

### New Components

| Component | File | Purpose |
|-----------|------|---------|
| `ModelBadgeShowcase` | `components/model-badge-showcase.tsx` | Displays earned/unearned badges with embed code copy buttons (wraps existing `BadgeEmbedCard`) |
| `ModelVarianceStats` | `components/model-variance-stats.tsx` | Shows min/max/avg/median/stddev for scores, cost, and speed with a BarChart comparison |
| `ModelTaskBreakdown` | `components/model-task-breakdown.tsx` | Expandable task cards with leaderboard comparison indicators (↑ Above/→ Average/↓ Below) |
| `ModelCostEfficiency` | `components/model-cost-efficiency.tsx` | Cost per run, execution time, speed, and value score cards with formula explanation |
| `ModelRunHistory` | `components/model-run-history.tsx` | Full run history table with benchmark version filter dropdown |

### Shared Utility Libraries

| File | Purpose |
|------|---------|
| `lib/scores.ts` | Score thresholds, color functions (Hex/Tailwind/bg), `computeStats()` — consolidates duplicate logic across the codebase |
| `lib/format.ts` | `fmtNum`, `fmtCurrency`, `fmtDuration`, `fmtSpeed`, `fmtCost` — consolidated number formatting utilities |
| `lib/scores.test.ts` | 24 tests for score utilities |
| `lib/format.test.ts` | 16 tests for format utilities |

### Modified Files

| File | Changes |
|------|---------|
| `app/model/[...slug]/page.tsx` | Complete rewrite: added tabbed layout (Overview/Tasks/Cost/Runs), badge fetching, best submission detail fetching, semantic HTML, ARIA labels |
| `app/api/og/route.tsx` | Imported `getScoreColorHex` from shared `lib/scores` (removed duplicate) |

### Test Files

| File | Tests |
|------|-------|
| `lib/scores.test.ts` | 24 tests — score thresholds, color functions, statistics calculations |
| `lib/format.test.ts` | 16 tests — number, currency, duration, speed formatting |
| `components/model-variance-stats.test.tsx` | 4 component-level tests |
| `components/model-run-history.test.tsx` | 8 component-level tests |

**Total: 52 new test cases** (reduced from ~500 lines of redundant per-component tests by testing shared utilities once)

## Features Implemented (per #76)

### 1. Badge Showcase Section ✅
- Displays embeddable badges for success/speed/cost/value metrics
- "Copy embed code" buttons for each badge (URL, Markdown, HTML) via existing `BadgeEmbedCard`
- Shows earned badges prominently and grayed-out unearned badges

### 2. Performance Overview ✅
- **Best/Average/Median scores** — visual comparison with color-coded stat cards
- **Score trend over time** — existing `ModelScoreTrend` LineChart preserved
- **Run variance** — statistical spread (min/max/avg/median/stddev) with horizontal BarChart

### 3. Task-Level Breakdown ✅
- Expandable sections showing per-task scores with criterion breakdown
- Highlights tasks where model excels (≥85%) vs struggles (<70%)
- Comparison to leaderboard average for each task (↑ Above/→ Average/↓ Below)
- Falls back through multiple submissions to find one with complete task data (≥5 tasks)

### 4. Cost & Efficiency Metrics ✅
- Cost per run breakdown (min/max/avg)
- Value score explanation with hover tooltip: `(score × 100) / avg cost`
- Speed metrics (avg time, cost/sec)
- Qualitative interpretation: Excellent/Good/Moderate/Low value
- **Graceful handling when API lacks cost/time data** — shows clear message explaining the limitation

### 5. Run History ✅
- Full table of all benchmark runs with Date/Score/Speed/Cost/Benchmark Version columns
- "Best" badge for top-performing run
- Filter by benchmark version via dropdown
- Links to individual submission detail pages

### 6. Code Quality Improvements ✅
- Consolidated duplicate `getScoreColor*` functions into `lib/scores.ts`
- Consolidated duplicate number/time formatting functions into `lib/format.ts`
- Replaced emoji icons with lucide-react components in new components
- Added null safety and type annotations throughout

## Known Issues & API Dependencies

### Cost & Efficiency Tab Shows "Data Unavailable"

**Root Cause:** The `/model-submissions` API endpoint does not return `total_cost_usd` or `total_execution_time_seconds` fields. Each submission item only includes:
```json
{ "id", "score_percentage", "total_score", "max_score", "timestamp", "is_best" }
```

**Evidence:** The `/leaderboard` endpoint **does** have aggregated cost/time data (`average_cost_usd`, `best_cost_usd`, `average_execution_time_seconds`), confirming the data exists in the database.

**Frontend mitigation:** The `ModelCostEfficiency` component detects missing data and displays a clear message:
> *Cost & Efficiency data unavailable. The API does not currently include per-run cost and execution time in the model submissions list. This data is available on the leaderboard endpoint and will be added to model submissions in a future API update.*

**Required API fix:** In `pinchbench-api`, the `/model-submissions` endpoint should include `total_cost_usd` and `total_execution_time_seconds` in each submission item.

### OG Image for Model Pages

**Issue:** Originally created `app/model/[...slug]/opengraph-image.tsx` for dynamic OG image generation. This caused a Turbopack build crash because `opengraph-image` cannot exist inside a catch-all `[...slug]` route.

**Resolution:** Deleted the file. OG images for model pages continue to work via the existing `/api/og/route.tsx` edge runtime endpoint. No functionality is lost.

## Design Considerations

- **Mobile-responsive**: Grid layouts use `grid-cols-1 sm:grid-cols-2 lg:grid-cols-5` breakpoints
- **Dark theme**: Consistent with existing dark-only theme (`bg-background`, `bg-card`, `border-border`, etc.)
- **Fast loading**: Server Component fetches data; client components are lightweight
- **Accessible**: Semantic `<h1>`, `<h2>` headings, `aria-label` on sections, proper button/link elements
- **Graceful degradation**: Badge and submission detail fetches are wrapped in try/catch; sections skip on error
- **Error-resilient**: Cost/time data gracefully handled when API doesn't provide it

## Data Flow

```
API (api.pinchbench.com)
  ├── GET /model-submissions?model=...&official={true|false}
  ├── GET /submissions/{bestSubmissionId}  (for task breakdown)
  └── getModelBadgeStatuses() → fetches recent submissions + computes badges

Server Component (page.tsx)
  ├── Fetches model submissions, badges, best submission detail
  ├── Transforms ApiTaskResult[] → TaskResult[]
  └── Passes data to tabbed client components

Tabs (client)
  ├── Overview: Stats + ModelVarianceStats + ModelScoreTrend
  ├── Tasks: ModelTaskBreakdown
  ├── Cost: ModelCostEfficiency (handles missing API data)
  └── Runs: ModelRunHistory (with version filter)
```

## Testing

### Unit Tests
- 52 test cases across 4 test files + 2 shared utility test files
- Tests cover all utility functions: statistics calculations, score colors, number formatting, value scores, filtering/sorting
- Existing `lib/badges.test.ts` tests continue to pass

### Manual Testing
- Verified live site structure at pinchbench.com
- Confirmed all component imports resolve correctly
- Verified TypeScript types match existing patterns
- Tested component prop interfaces against API response types

## Notes

- The model page now uses `Tabs` from shadcn/ui for navigation between sections
- Badge fetching uses the existing `getModelBadgeStatuses()` function from `lib/badges.ts`
- Task breakdown requires fetching the best submission detail separately (not included in model-submissions response)
- The task data fetcher tries up to 3 submissions to find one with complete task data (≥5 tasks), since the `is_best` submission may be a partial run
- All new components export utility functions for testability
- Score scale is 0–1 decimal (`score_percentage` from API); all displays multiply by 100 for percentage
