### PR TITLE
feat(task-categories): add task category filtering and breakdown views

### DIFF
--- a/app/submission/[id]/page.tsx
+++ b/app/submission/[id]/page.tsx
@@ -16,6 +16,7 @@ import { PROVIDER_COLORS } from '@/lib/types'
 import { formatDistanceToNow } from 'date-fns'
 import { fetchSubmission } from '@/lib/api'
 import { transformSubmission } from '@/lib/transforms'
+import { aggregateCategoryScores } from '@/lib/category-scores'
 
 interface SubmissionPageProps {
   params: Promise<{ id: string }>
@@ -76,18 +77,7 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
     notFound()
   }
 
-  const categoryStats = submission.task_results.reduce(
-    (acc, task) => {
-      if (!acc[task.category]) {
-        acc[task.category] = { total: 0, max: 0, count: 0 }
-      }
-      acc[task.category].total += task.score
-      acc[task.category].max += task.max_score
-      acc[task.category].count += 1
-      return acc
-    },
-    {} as Record<string, { total: number; max: number; count: number }>
-  )
+  const categoryStats = aggregateCategoryScores(submission.task_results)
 
   const badgeStatuses = await getModelBadgeStatuses(submission.model, {
     officialOnly,
@@ -256,8 +246,8 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
           </div>
 
           <div className="lg:col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {Object.entries(categoryStats).map(([category, stats]) => {
-              const percentage = (stats.total / stats.max) * 100
+            {categoryStats.map((stats) => {
+              const percentage = stats.percentage
               const getColor = () => {
                 if (percentage >= 85) return 'text-green-500'
                 if (percentage >= 70) return 'text-yellow-500'
@@ -266,11 +256,11 @@ export default async function SubmissionPage({ params, searchParams }: Submissio
 
               return (
                 <Card
-                  key={category}
+                  key={stats.category}
                   className="p-4 bg-card border-border flex flex-col"
                 >
                   <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">
-                    {category}
+                    {stats.icon} {stats.label}
                   </div>
                   <div className="flex items-baseline gap-2 mb-1">
                     <span className={`text-2xl font-bold ${getColor()}`}>

--- a/components/category-pills.tsx
+++ b/components/category-pills.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { TASK_CATEGORIES } from '@/lib/types'
+
+interface CategoryPillsProps {
+  selectedCategories: string[]
+  onCategoriesChange: (categories: string[]) => void
+  disabled?: boolean
+  activeTaskCount?: number | null
+  className?: string
+}
+
+export function CategoryPills({
+  selectedCategories,
+  onCategoriesChange,
+  disabled = false,
+  activeTaskCount,
+  className = '',
+}: CategoryPillsProps) {
+  const selected = new Set(selectedCategories)
+  const hasFilter = selectedCategories.length > 0
+
+  const toggleCategory = (category: string) => {
+    if (disabled) return
+    onCategoriesChange(
+      selected.has(category)
+        ? selectedCategories.filter((c) => c !== category)
+        : [...selectedCategories, category],
+    )
+  }
+
+  return (
+    <div className={`flex flex-wrap items-center gap-2 ${className}`} data-share-exclude="true">
+      <span className="text-xs font-medium text-muted-foreground shrink-0">
+        Category:
+      </span>
+      <button
+        type="button"
+        onClick={() => onCategoriesChange([])}
+        disabled={disabled}
+        className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors border disabled:opacity-60 disabled:cursor-wait ${
+          !hasFilter
+            ? 'bg-primary text-primary-foreground border-primary'
+            : 'bg-secondary text-secondary-foreground border-border hover:bg-secondary/80'
+        }`}
+      >
+        All
+      </button>
+      {TASK_CATEGORIES.map((category) => {
+        const active = selected.has(category.id)
+        return (
+          <button
+            key={category.id}
+            type="button"
+            onClick={() => toggleCategory(category.id)}
+            disabled={disabled}
+            title={category.description}
+            aria-pressed={active}
+            className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors border disabled:opacity-60 disabled:cursor-wait ${
+              active
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-secondary text-secondary-foreground border-border hover:bg-secondary/80'
+            }`}
+          >
+            <span aria-hidden="true">{category.icon}</span>
+            <span>{category.shortLabel}</span>
+          </button>
+        )
+      })}
+      {hasFilter && activeTaskCount != null ? (
+        <span className="text-xs text-muted-foreground/70">
+          {activeTaskCount} task{activeTaskCount === 1 ? '' : 's'} selected
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/components/leaderboard-header.tsx
+++ b/components/leaderboard-header.tsx
@@ -5,6 +5,7 @@ import { Github, BarChart3, Zap, Gem, DollarSign, Trophy } from 'lucide-react'
 import type { LeaderboardEntry } from '@/lib/types'
 import { ModelSearch } from '@/components/model-search'
 import { FilterPanel } from '@/components/filter-panel'
+import { CategoryPills } from '@/components/category-pills'
 import type { BenchmarkVersion } from '@/lib/types'
 
 type ViewMode = 'success' | 'speed' | 'cost' | 'value' | 'graphs'
@@ -26,6 +27,9 @@ interface LeaderboardHeaderProps {
   sortMode: SortMode
   officialOnly: boolean
   openWeightsOnly: boolean
+  selectedCategories: string[]
+  categoryDataLoading: boolean
+  activeCategoryTaskCount: number | null
   modelSearchValue: string
   maxCostFilter: string
   showZeroCostResults: boolean
@@ -35,6 +39,7 @@ interface LeaderboardHeaderProps {
   onSortModeChange: (mode: SortMode) => void
   onOfficialOnlyChange: (officialOnly: boolean) => void
   onOpenWeightsOnlyChange: (openWeightsOnly: boolean) => void
+  onCategoriesChange: (categories: string[]) => void
   onClearProviderFilter: () => void
   onModelSearchChange: (value: string) => void
   onMaxCostFilterChange: (value: string) => void
@@ -63,6 +68,9 @@ export function LeaderboardHeader({
   sortMode,
   officialOnly,
   openWeightsOnly,
+  selectedCategories,
+  categoryDataLoading,
+  activeCategoryTaskCount,
   modelSearchValue,
   maxCostFilter,
   showZeroCostResults,
@@ -72,6 +80,7 @@ export function LeaderboardHeader({
   onSortModeChange,
   onOfficialOnlyChange,
   onOpenWeightsOnlyChange,
+  onCategoriesChange,
   onClearProviderFilter,
   onModelSearchChange,
   onMaxCostFilterChange,
@@ -202,6 +211,18 @@ export function LeaderboardHeader({
               </Link>
             </div>
           </div>
+        </div>
+      </div>
+
+      {/* Category filter pills */}
+      <div className="border-t border-border/50">
+        <div className="max-w-7xl mx-auto px-4 md:px-6 py-2">
+          <CategoryPills
+            selectedCategories={selectedCategories}
+            onCategoriesChange={onCategoriesChange}
+            disabled={categoryDataLoading}
+            activeTaskCount={activeCategoryTaskCount}
+          />
         </div>
       </div>
 

--- a/components/leaderboard-view.tsx
+++ b/components/leaderboard-view.tsx
@@ -2,8 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
-import type { LeaderboardEntry, BenchmarkVersion, SortMode } from '@/lib/types'
+import type { LeaderboardEntry, BenchmarkVersion, SortMode, TaskResult } from '@/lib/types'
 import { PROVIDER_COLORS } from '@/lib/types'
+import { fetchSubmissionClient } from '@/lib/api'
+import { calculateCategoryFilteredScore, calculateRanksByPercentage } from '@/lib/category-scores'
+import { transformSubmission } from '@/lib/transforms'
 import { SimpleLeaderboard } from '@/components/simple-leaderboard'
 import { ScatterGraphs } from '@/components/scatter-graphs'
 import { TaskHeatmap } from '@/components/task-heatmap'
@@ -70,6 +73,9 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
     const [sortMode, setSortModeState] = useState<SortMode>(initialSortMode)
     const [maxCostFilter, setMaxCostFilterState] = useState<string>(initialBudget)
     const [showZeroCostResults, setShowZeroCostResultsState] = useState<boolean>(initialZeroCost)
+    const [taskDataBySubmission, setTaskDataBySubmission] = useState<Record<string, TaskResult[]>>({})
+    const [taskDataLoading, setTaskDataLoading] = useState(false)
+    const [taskDataError, setTaskDataError] = useState<string | null>(null)
 
     // Helper to update URL params without full page reload
     const updateUrl = useCallback((updates: Record<string, string | null>) => {
@@ -152,6 +158,8 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
         [searchParams]
     )
 
+    const categoryFilterActive = selectedCategories.length > 0
+
     // Business-level filters only (provider filter, open weights).
     // Used for legend provider list and all charts/tables.
     const businessFilteredEntries = useMemo(() => {
@@ -192,6 +200,108 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
         }
     }, [providerFilter, openWeightsOnly, businessFilteredEntries])
 
+    // Category filtering: fetch task data when category filter is active
+    useEffect(() => {
+        if (!categoryFilterActive) {
+            setTaskDataLoading(false)
+            setTaskDataError(null)
+            return
+        }
+
+        const missingEntries = filteredEntries.filter(
+            (entry) => !taskDataBySubmission[entry.submission_id]
+        )
+
+        if (missingEntries.length === 0) {
+            setTaskDataLoading(false)
+            return
+        }
+
+        let cancelled = false
+
+        async function loadTaskData(entriesToLoad: LeaderboardEntry[]) {
+            setTaskDataLoading(true)
+            setTaskDataError(null)
+
+            try {
+                const loaded: Record<string, TaskResult[]> = {}
+                const batchSize = 5
+
+                for (let i = 0; i < entriesToLoad.length; i += batchSize) {
+                    if (cancelled) return
+                    const batch = entriesToLoad.slice(i, i + batchSize)
+                    const results = await Promise.all(
+                        batch.map(async (entry) => {
+                            try {
+                                const response = await fetchSubmissionClient(entry.submission_id)
+                                return {
+                                    submissionId: entry.submission_id,
+                                    tasks: transformSubmission(response.submission).task_results,
+                                }
+                            } catch {
+                                return null
+                            }
+                        })
+                    )
+
+                    for (const result of results) {
+                        if (result) loaded[result.submissionId] = result.tasks
+                    }
+                }
+
+                if (!cancelled) {
+                    if (Object.keys(loaded).length > 0) {
+                        setTaskDataBySubmission((current) => ({ ...current, ...loaded }))
+                    }
+                    setTaskDataLoading(false)
+                }
+            } catch {
+                if (!cancelled) {
+                    setTaskDataError('Unable to load category scores')
+                    setTaskDataLoading(false)
+                }
+            }
+        }
+
+        loadTaskData(missingEntries)
+        return () => { cancelled = true }
+    }, [categoryFilterActive, filteredEntries, taskDataBySubmission])
+
+    const categoryScoredEntries = useMemo(() => {
+        if (!categoryFilterActive) return filteredEntries
+
+        const scored: LeaderboardEntry[] = []
+
+        for (const entry of filteredEntries) {
+            const tasks = taskDataBySubmission[entry.submission_id]
+            if (!tasks) continue
+            const categoryScore = calculateCategoryFilteredScore(tasks, selectedCategories)
+            if (categoryScore.percentage == null || categoryScore.count === 0) continue
+            scored.push({
+                ...entry,
+                percentage: categoryScore.percentage,
+                average_score_percentage: null,
+            })
+        }
+
+        scored.sort((a, b) => b.percentage - a.percentage)
+
+        return calculateRanksByPercentage(scored)
+    }, [categoryFilterActive, filteredEntries, selectedCategories, taskDataBySubmission])
+
+    const activeCategoryTaskCount = useMemo(() => {
+        if (!categoryFilterActive) return null
+        const counts = new Set<number>()
+        for (const entry of filteredEntries) {
+            const tasks = taskDataBySubmission[entry.submission_id]
+            if (!tasks) continue
+            const count = calculateCategoryFilteredScore(tasks, selectedCategories).count
+            if (count > 0) counts.add(count)
+        }
+        if (counts.size > 0) return Math.max(...counts)
+        return taskDataLoading ? null : 0
+    }, [categoryFilterActive, filteredEntries, selectedCategories, taskDataBySubmission, taskDataLoading])
+
     const providerColor = providerFilter
         ? PROVIDER_COLORS[providerFilter.toLowerCase()] || '#666'
         : undefined
@@ -208,6 +318,7 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
         <div className="min-h-screen bg-background">
             <LeaderboardHeader
                 entries={entries}
+                filteredEntryCount={headerEntries.length}
                 totalRuns={totalRuns}
                 versions={versions}
                 currentVersion={currentVersion}
@@ -219,6 +330,9 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                 sortMode={sortMode}
                 officialOnly={officialOnlyState}
                 openWeightsOnly={openWeightsOnly}
+                selectedCategories={selectedCategories}
+                categoryDataLoading={taskDataLoading}
+                activeCategoryTaskCount={activeCategoryTaskCount}
                 modelSearchValue={modelSearch}
                 maxCostFilter={maxCostFilter}
                 showZeroCostResults={showZeroCostResults}
@@ -228,6 +342,7 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                 onSortModeChange={setSortMode}
                 onOfficialOnlyChange={setOfficialOnly}
                 onOpenWeightsOnlyChange={setOpenWeightsOnly}
+                onCategoriesChange={setSelectedCategories}
                 onClearProviderFilter={() => setProviderFilter(null)}
                 onModelSearchChange={handleModelSearchChange}
                 onMaxCostFilterChange={setMaxCostFilter}
@@ -300,8 +415,19 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                         <KiloClawAdCard />
                     </div>
                 ) : (
+                    <>
+                    {categoryFilterActive && taskDataError ? (
+                        <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                            {taskDataError}
+                        </div>
+                    ) : null}
+                    {categoryFilterActive && taskDataLoading ? (
+                        <div className="mb-4 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                            Loading category-specific scores for {filteredEntries.length} models...
+                        </div>
+                    ) : null}
                     <SimpleLeaderboard
-                        entries={businessFilteredEntries}
+                        entries={categoryScoredEntries}
                         view={view as 'success' | 'speed' | 'cost' | 'value'}
                         scoreMode={scoreMode}
                         sortMode={sortMode}
@@ -309,12 +435,15 @@ export function LeaderboardView({ entries, lastUpdated, versions, currentVersion
                         showZeroCostResults={showZeroCostResults}
                         benchmarkVersion={currentVersion}
                         officialOnly={officialOnlyState}
+                        selectedCategories={selectedCategories}
+                        activeCategoryTaskCount={activeCategoryTaskCount}
                         onScoreModeChange={setScoreMode}
                         onSortModeChange={setSortMode}
                         onMaxCostFilterChange={setMaxCostFilter}
                         onShowZeroCostResultsChange={setShowZeroCostResults}
                         onProviderClick={setProviderFilter}
                     />
+                    </>
                 )}
             </main>
         </div>

--- a/components/simple-leaderboard.tsx
+++ b/components/simple-leaderboard.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { DEFAULT_TABLE_ROW_LIMIT } from '@/lib/constants'
 import type { LeaderboardEntry, SortMode } from '@/lib/types'
-import { PROVIDER_COLORS } from '@/lib/types'
+import { PROVIDER_COLORS, TASK_CATEGORY_BY_ID } from '@/lib/types'
 import { ShareableWrapper } from '@/components/shareable-wrapper'
 import { KiloClawAdCard } from '@/components/kiloclaw-ad-card'
 
@@ -20,6 +20,8 @@ interface SimpleLeaderboardProps {
   showZeroCostResults: boolean
   benchmarkVersion?: string | null
   officialOnly: boolean
+  selectedCategories?: string[]
+  activeCategoryTaskCount?: number | null
   onScoreModeChange?: (mode: 'best' | 'average') => void
   onSortModeChange?: (mode: SortMode) => void
   onMaxCostFilterChange?: (value: string) => void
@@ -96,15 +98,22 @@ export function SimpleLeaderboard({
   showZeroCostResults,
   benchmarkVersion,
   officialOnly,
+  selectedCategories = [],
+  activeCategoryTaskCount,
   onProviderClick,
 }: SimpleLeaderboardProps) {
   const [showAllEntries, setShowAllEntries] = useState(false)
+  const categoryFilterActive = selectedCategories.length > 0
+  const selectedCategoryLabels = selectedCategories
+    .map((cat) => TASK_CATEGORY_BY_ID[cat]?.label ?? cat.replace(/_/g, ' '))
+    .join(', ')
 
   const submissionHref = (submissionId: string) => (
     officialOnly ? `/submission/${submissionId}` : `/submission/${submissionId}?official=false`
   )
 
   const getSortScorePercentage = (entry: LeaderboardEntry) => {
+    if (categoryFilterActive) return entry.percentage
     if (scoreMode === 'average') {
       return entry.average_score_percentage != null
         ? entry.average_score_percentage * 100
@@ -413,15 +422,24 @@ export function SimpleLeaderboard({
         )}
 
         <p className="text-sm text-muted-foreground mb-2">
-          Percentage of{' '}
-          <Link
-            href="https://github.com/pinchbench/skill/tree/main/tasks"
-            className="underline underline-offset-2 hover:text-foreground"
-            target="_blank"
-          >
-            tasks
-          </Link>{' '}
-          completed successfully across standardized OpenClaw agent tests
+          {categoryFilterActive ? (
+            <>
+              Best-run scores recalculated from {selectedCategoryLabels}
+              {activeCategoryTaskCount != null ? ` (${activeCategoryTaskCount} tasks)` : ''}.
+            </>
+          ) : (
+            <>
+              Percentage of{' '}
+              <Link
+                href="https://github.com/pinchbench/skill/tree/main/tasks"
+                className="underline underline-offset-2 hover:text-foreground"
+                target="_blank"
+              >
+                tasks
+              </Link>{' '}
+              completed successfully across standardized OpenClaw agent tests
+            </>
+          )}
         </p>
         <p className="text-xs text-muted-foreground mb-6 flex items-center gap-1.5">
           <Info className="h-3 w-3 flex-shrink-0" />
@@ -442,20 +460,24 @@ export function SimpleLeaderboard({
 
         {/* Bar Chart - hidden on mobile */}
         <ShareableWrapper
-          title="Success Rate by Model"
-          subtitle={`${displayedEntries.length} models${sortMode === 'value' ? ' • sorted by value' : ` • sorted by ${scoreMode} score`}`}
+          title={categoryFilterActive ? 'Category Score by Model' : 'Success Rate by Model'}
+          subtitle={categoryFilterActive
+            ? `${displayedEntries.length} models • ${selectedCategoryLabels}`
+            : `${displayedEntries.length} models${sortMode === 'value' ? ' • sorted by value' : ` • sorted by ${scoreMode} score`}`}
           alwaysShowButton
         >
           <div className="hidden md:block bg-card border border-border rounded-lg p-6 mb-6">
             <div className="mb-4 flex items-center gap-5 text-xs text-muted-foreground">
               <span className="inline-flex items-center gap-2">
                 <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: BEST_SCORE_COLOR }} />
-                Best Score
+                {categoryFilterActive ? 'Category Score' : 'Best Score'}
               </span>
-              <span className="inline-flex items-center gap-2">
-                <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: AVG_SCORE_COLOR }} />
-                Average Score
-              </span>
+              {!categoryFilterActive && (
+                <span className="inline-flex items-center gap-2">
+                  <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: AVG_SCORE_COLOR }} />
+                  Average Score
+                </span>
+              )}
             </div>
             <div className="space-y-3">
               {(showAllEntries ? displayedEntries.concat(nullEntries) : displayedEntries).map((entry) => {
@@ -501,21 +523,23 @@ export function SimpleLeaderboard({
                                   {bestPct.toFixed(1)}%
                                 </span>
                               </div>
-                              <div className="bg-muted rounded-full h-7 relative overflow-hidden">
-                                <div
-                                  className="h-full rounded-full transition-all duration-300 group-hover:opacity-80"
-                                  style={{
-                                    width: `${avgPct ?? 0}%`,
-                                    backgroundColor: AVG_SCORE_COLOR,
-                                  }}
-                                />
-                                <span
-                                  className="absolute inset-y-0 right-3 flex items-center text-xs font-bold text-foreground"
-                                  style={{ textShadow: '0 1px 2px rgba(0,0,0,0.5)' }}
-                                >
-                                  {avgPct == null ? 'N/A' : `${avgPct.toFixed(1)}%`}
-                                </span>
-                              </div>
+                              {!categoryFilterActive && (
+                                <div className="bg-muted rounded-full h-7 relative overflow-hidden">
+                                  <div
+                                    className="h-full rounded-full transition-all duration-300 group-hover:opacity-80"
+                                    style={{
+                                      width: `${avgPct ?? 0}%`,
+                                      backgroundColor: AVG_SCORE_COLOR,
+                                    }}
+                                  />
+                                  <span
+                                    className="absolute inset-y-0 right-3 flex items-center text-xs font-bold text-foreground"
+                                    style={{ textShadow: '0 1px 2px rgba(0,0,0,0.5)' }}
+                                  >
+                                    {avgPct == null ? 'N/A' : `${avgPct.toFixed(1)}%`}
+                                  </span>
+                                </div>
+                              )}
                             </div>
                             <div className="w-24 text-right space-y-1.5">
                               <div>
@@ -526,14 +550,16 @@ export function SimpleLeaderboard({
                                   {bestPct.toFixed(1)}%
                                 </span>
                               </div>
-                              <div>
-                                <span
-                                  className="text-sm font-bold"
-                                  style={{ color: AVG_SCORE_COLOR }}
-                                >
-                                  {avgPct == null ? 'N/A' : `${avgPct.toFixed(1)}%`}
-                                </span>
-                              </div>
+                              {!categoryFilterActive && (
+                                <div>
+                                  <span
+                                    className="text-sm font-bold"
+                                    style={{ color: AVG_SCORE_COLOR }}
+                                  >
+                                    {avgPct == null ? 'N/A' : `${avgPct.toFixed(1)}%`}
+                                  </span>
+                                </div>
+                              )}
                             </div>
                           </div>
                         </div>
@@ -547,9 +573,9 @@ export function SimpleLeaderboard({
                         </span>
                       </p>
                       <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-                        <span className="text-muted-foreground">Best score</span>
+                        <span className="text-muted-foreground">{categoryFilterActive ? 'Category score' : 'Best score'}</span>
                         <span className="text-foreground font-medium text-right">{bestPct.toFixed(1)}%</span>
-                        {avgPct != null && (
+                        {!categoryFilterActive && avgPct != null && (
                           <>
                             <span className="text-muted-foreground">Avg score</span>
                             <span className="text-foreground font-medium text-right">{avgPct.toFixed(1)}%</span>
@@ -608,8 +634,10 @@ export function SimpleLeaderboard({
 
         {/* Simple Table */}
         <ShareableWrapper
-          title="Success Rate Rankings"
-          subtitle={`${displayedEntries.length} models • sorted by ${scoreMode} score`}
+          title={categoryFilterActive ? 'Category Score Rankings' : 'Success Rate Rankings'}
+          subtitle={categoryFilterActive
+            ? `${displayedEntries.length} models • ${selectedCategoryLabels}`
+            : `${displayedEntries.length} models • sorted by ${scoreMode} score`}
         >
           <div className="bg-card border border-border rounded-lg overflow-hidden">
             <table className="w-full">
@@ -622,16 +650,18 @@ export function SimpleLeaderboard({
                     Provider
                   </th>
                   <th className="px-2 md:px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase">
-                    <span className="md:hidden">{scoreMode === 'best' ? 'Best %' : 'Avg %'}</span>
-                    <span className="hidden md:inline">Best %</span>
+                    <span className="md:hidden">{categoryFilterActive ? 'Cat %' : scoreMode === 'best' ? 'Best %' : 'Avg %'}</span>
+                    <span className="hidden md:inline">{categoryFilterActive ? 'Category %' : 'Best %'}</span>
                   </th>
-                  <th className="hidden md:table-cell px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase">
-                    <ColumnTooltip
-                      label="Avg %"
-                      description="Average success rate across all runs for this model. Click any row to see the per-task scoring breakdown with individual pass/fail details."
-                      benchmarkVersion={benchmarkVersion}
-                    />
-                  </th>
+                  {!categoryFilterActive && (
+                    <th className="hidden md:table-cell px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase">
+                      <ColumnTooltip
+                        label="Avg %"
+                        description="Average success rate across all runs for this model. Click any row to see the per-task scoring breakdown with individual pass/fail details."
+                        benchmarkVersion={benchmarkVersion}
+                      />
+                    </th>
+                  )}
                   {sortMode === 'value' && (
                     <th className="hidden md:table-cell px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase">
                       <ColumnTooltip
@@ -649,8 +679,8 @@ export function SimpleLeaderboard({
                   const avgPct = entry.average_score_percentage != null
                     ? entry.average_score_percentage * 100
                     : null
-                  const mobileScore = scoreMode === 'best' ? bestPct : avgPct
-                  const mobileScoreColor = scoreMode === 'best' ? BEST_SCORE_COLOR : AVG_SCORE_COLOR
+                  const mobileScore = categoryFilterActive || scoreMode === 'best' ? bestPct : avgPct
+                  const mobileScoreColor = categoryFilterActive || scoreMode === 'best' ? BEST_SCORE_COLOR : AVG_SCORE_COLOR
                   return (
                     <tr
                       key={entry.submission_id}
@@ -700,11 +730,13 @@ export function SimpleLeaderboard({
                           {bestPct.toFixed(1)}%
                         </span>
                       </td>
-                      <td className="hidden md:table-cell px-4 py-3 text-right">
-                        <span className="text-sm font-medium" style={{ color: AVG_SCORE_COLOR }}>
-                          {avgPct == null ? 'N/A' : `${avgPct.toFixed(1)}%`}
-                        </span>
-                      </td>
+                      {!categoryFilterActive && (
+                        <td className="hidden md:table-cell px-4 py-3 text-right">
+                          <span className="text-sm font-medium" style={{ color: AVG_SCORE_COLOR }}>
+                            {avgPct == null ? 'N/A' : `${avgPct.toFixed(1)}%`}
+                          </span>
+                        </td>
+                      )}
                       {sortMode === 'value' && (
                         <td className="hidden md:table-cell px-4 py-3 text-right">
                           {entry.value_score != null ? (

--- a/components/task-heatmap.tsx
+++ b/components/task-heatmap.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { LeaderboardEntry } from '@/lib/types'
-import { PROVIDER_COLORS, CATEGORY_ICONS } from '@/lib/types'
+import { PROVIDER_COLORS } from '@/lib/types'
 import { fetchSubmissionClient } from '@/lib/api'
 import { transformSubmission } from '@/lib/transforms'
 import { ShareableWrapper } from '@/components/shareable-wrapper'
+import { CategoryPills } from '@/components/category-pills'
+import { getCategoryMeta } from '@/lib/category-scores'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 interface TaskHeatmapProps {
@@ -273,18 +275,6 @@ export function TaskHeatmap({ entries, selectedCategories, onCategoriesChange }:
     return allTasks.filter((t) => set.has(t.category.toLowerCase()))
   }, [allTasks, selectedCategories, categoryFilterActive])
 
-  const availableCategories = useMemo(() => {
-    const seen = new Set<string>()
-    const order: string[] = []
-    for (const t of allTasks) {
-      if (!seen.has(t.category)) {
-        seen.add(t.category)
-        order.push(t.category)
-      }
-    }
-    return order
-  }, [allTasks])
-
   const modelFilteredPercentage = useMemo(() => {
     const map = new Map<string, number>()
     if (!categoryFilterActive || filteredTasks.length === 0) return map
@@ -426,40 +416,12 @@ export function TaskHeatmap({ entries, selectedCategories, onCategoriesChange }:
         </div>
       ) : null}
 
-      {/* Category chips */}
-      <div className="flex flex-wrap items-center gap-2 mb-4">
-        <span className="text-xs text-muted-foreground shrink-0">Categories:</span>
-        <button
-          type="button"
-          onClick={() => onCategoriesChange([])}
-          className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors border ${
-            !categoryFilterActive
-              ? 'bg-primary text-primary-foreground border-primary'
-              : 'bg-secondary text-secondary-foreground border-border hover:bg-secondary/80'
-          }`}
-        >
-          All
-        </button>
-        {availableCategories.map((cat) => {
-          const active =
-            categoryFilterActive && selectedCategories.includes(cat.toLowerCase())
-          return (
-            <button
-              key={cat}
-              type="button"
-              onClick={() => toggleCategory(cat)}
-              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium transition-colors border capitalize ${
-                active
-                  ? 'bg-primary text-primary-foreground border-primary'
-                  : 'bg-secondary text-secondary-foreground border-border hover:bg-secondary/80'
-              }`}
-            >
-              <span>{CATEGORY_ICONS[cat] ?? CATEGORY_ICONS.other}</span>
-              {cat}
-            </button>
-          )
-        })}
-      </div>
+      <CategoryPills
+        selectedCategories={selectedCategories}
+        onCategoriesChange={onCategoriesChange}
+        activeTaskCount={categoryFilterActive ? filteredTasks.length : null}
+        className="mb-4"
+      />
 
       {/* Incremental loading progress — shown while fetching remaining entries */}
       {isIncrementalLoad && (
@@ -539,8 +501,8 @@ export function TaskHeatmap({ entries, selectedCategories, onCategoriesChange }:
                     colSpan={group.count}
                     className="border-b border-border px-1 py-1.5 text-center font-medium text-muted-foreground bg-muted/30"
                   >
-                    <span title={group.category} className="capitalize">
-                      {CATEGORY_ICONS[group.category] || ''} {group.category}
+                    <span title={getCategoryMeta(group.category).label}>
+                      {getCategoryMeta(group.category).icon} {getCategoryMeta(group.category).shortLabel}
                     </span>
                   </th>
                 ))}
@@ -578,7 +540,7 @@ export function TaskHeatmap({ entries, selectedCategories, onCategoriesChange }:
                       </TooltipTrigger>
                       <TooltipContent side="top" className="max-w-xs">
                         <p className="font-medium">{task.taskName}</p>
-                        <p className="text-xs text-muted-foreground capitalize">{task.category}</p>
+                        <p className="text-xs text-muted-foreground">{getCategoryMeta(task.category).label}</p>
                       </TooltipContent>
                     </Tooltip>
                   </th>

--- a/lib/category-scores.ts
+++ b/lib/category-scores.ts
@@ -1,0 +1,110 @@
+import type { LeaderboardEntry, TaskResult } from "@/lib/types";
+import { TASK_CATEGORY_BY_ID } from "@/lib/types";
+
+export interface CategoryScore {
+  category: string;
+  label: string;
+  shortLabel: string;
+  icon: string;
+  total: number;
+  max: number;
+  count: number;
+  percentage: number;
+}
+
+export interface CategoryFilteredScore {
+  total: number;
+  max: number;
+  count: number;
+  percentage: number | null;
+}
+
+export function normalizeCategoryId(category: string): string {
+  return category.trim().toLowerCase();
+}
+
+export function getCategoryMeta(category: string) {
+  const normalized = normalizeCategoryId(category);
+  return TASK_CATEGORY_BY_ID[normalized] ?? {
+    id: normalized,
+    label: normalized.replace(/_/g, " "),
+    shortLabel: normalized.replace(/_/g, " "),
+    icon: "📌",
+    description: "Benchmark tasks in this category",
+  };
+}
+
+export function aggregateCategoryScores(tasks: TaskResult[]): CategoryScore[] {
+  const scores = tasks.reduce(
+    (acc, task) => {
+      const category = normalizeCategoryId(task.category || "other");
+      if (!acc[category]) {
+        acc[category] = { total: 0, max: 0, count: 0 };
+      }
+      acc[category].total += task.score;
+      acc[category].max += task.max_score;
+      acc[category].count += 1;
+      return acc;
+    },
+    {} as Record<string, { total: number; max: number; count: number }>,
+  );
+
+  return Object.entries(scores)
+    .map(([category, score]) => {
+      const meta = getCategoryMeta(category);
+      return {
+        category,
+        label: meta.label,
+        shortLabel: meta.shortLabel,
+        icon: meta.icon,
+        total: score.total,
+        max: score.max,
+        count: score.count,
+        percentage: score.max > 0 ? (score.total / score.max) * 100 : 0,
+      };
+    })
+    .sort((a, b) => b.percentage - a.percentage || a.label.localeCompare(b.label));
+}
+
+export function calculateCategoryFilteredScore(
+  tasks: TaskResult[],
+  selectedCategories: string[],
+): CategoryFilteredScore {
+  const categorySet = new Set(selectedCategories.map(normalizeCategoryId));
+  let total = 0;
+  let max = 0;
+  let count = 0;
+
+  for (const task of tasks) {
+    if (!categorySet.has(normalizeCategoryId(task.category || "other"))) continue;
+    total += task.score;
+    max += task.max_score;
+    count += 1;
+  }
+
+  return {
+    total,
+    max,
+    count,
+    percentage: max > 0 ? (total / max) * 100 : null,
+  };
+}
+
+export function calculateRanksByPercentage(
+  entries: LeaderboardEntry[],
+): LeaderboardEntry[] {
+  let lastRank = 0;
+  let lastPercentage = Number.NaN;
+
+  return entries.map((entry, index) => {
+    if (
+      lastRank > 0 &&
+      Math.abs(entry.percentage - lastPercentage) <= 1e-6
+    ) {
+      return { ...entry, rank: lastRank };
+    }
+    lastRank = index + 1;
+    lastPercentage = entry.percentage;
+    return { ...entry, rank: lastRank };
+  });
+}

--- a/lib/task-metadata.ts
+++ b/lib/task-metadata.ts
@@ -1,14 +1,132 @@
 export const TASK_FALLBACK: Record<string, { name: string; category: string }> =
   {
-    task_00_sanity: { name: "Sanity Check", category: "validation" },
-    task_01_calendar: { name: "Calendar Event", category: "calendar" },
-    task_02_stock: { name: "Stock Research", category: "api" },
-    task_03_blog: { name: "Blog Post", category: "writing" },
-    task_04_weather: { name: "Weather Script", category: "coding" },
-    task_05_summary: { name: "Document Summary", category: "comprehension" },
-    task_06_events: { name: "Events Research", category: "research" },
-    task_07_email: { name: "Email Draft", category: "writing" },
-    task_08_memory: { name: "Memory Retrieval", category: "context" },
-    task_09_files: { name: "File Operations", category: "coding" },
-    task_10_workflow: { name: "Multi-step Workflow", category: "complex" },
+    task_00_sanity: { name: "Sanity Check", category: "core_agent" },
+    task_01_calendar: { name: "Calendar Event", category: "productivity" },
+    task_02_stock: { name: "Stock Research", category: "data_analysis" },
+    task_03_blog: { name: "Blog Post", category: "writing_content" },
+    task_04_weather: { name: "Weather Script", category: "code_devops" },
+    task_05_summary: { name: "Document Summary", category: "writing_content" },
+    task_06_events: { name: "Events Research", category: "research_knowledge" },
+    task_07_email: { name: "Email Draft", category: "productivity" },
+    task_08_memory: { name: "Memory Retrieval", category: "core_agent" },
+    task_09_files: { name: "File Operations", category: "core_agent" },
+    task_10_workflow: { name: "Multi-step Workflow", category: "core_agent" },
+
+    task_test_generation: { name: "Test Generation", category: "code_devops" },
+    task_k8s_debugging: { name: "K8s Debugging", category: "code_devops" },
+    task_cicd_pipeline_debug: { name: "CI/CD Pipeline Debug", category: "code_devops" },
+    task_dockerfile_optimization: { name: "Dockerfile Optimization", category: "code_devops" },
+    task_selector_fix: { name: "Selector Fix", category: "code_devops" },
+    task_multi_file_refactoring: { name: "Multi-file Refactoring", category: "code_devops" },
+    task_playwright_e2e: { name: "Playwright E2E", category: "code_devops" },
+    task_git_rescue_recovery: { name: "Git Rescue Recovery", category: "code_devops" },
+
+    task_spreadsheet_summary: { name: "Spreadsheet Summary", category: "data_analysis" },
+    task_financial_ratio_calculation: { name: "Financial Ratio Calculation", category: "data_analysis" },
+    task_earnings_analysis: { name: "Earnings Analysis", category: "data_analysis" },
+
+    task_humanizer: { name: "Humanizer", category: "writing_content" },
+    task_readme_generation: { name: "README Generation", category: "writing_content" },
+    task_commit_message_writer: { name: "Commit Message Writer", category: "writing_content" },
+    task_eli5_pdf_summary: { name: "ELI5 PDF Summary", category: "writing_content" },
+
+    task_todo_list_cleanup: { name: "Todo List Cleanup", category: "productivity" },
+    task_daily_summary: { name: "Daily Summary", category: "productivity" },
+    task_pdf_to_calendar: { name: "PDF to Calendar", category: "productivity" },
+
+    task_market_research: { name: "Market Research", category: "research_knowledge" },
+    task_executive_lookup: { name: "Executive Lookup", category: "research_knowledge" },
+    task_polymarket_briefing: { name: "Polymarket Briefing", category: "research_knowledge" },
+    task_contract_analysis: { name: "Contract Analysis", category: "research_knowledge" },
+    task_skill_search: { name: "Skill Search", category: "research_knowledge" },
+
+    task_access_log_anomaly: { name: "Access Log Anomaly", category: "security_ops" },
+    task_cve_security_triage: { name: "CVE Security Triage", category: "security_ops" },
+    task_gh_issue_triage: { name: "GitHub Issue Triage", category: "security_ops" },
+
+    task_openclaw_comprehension: { name: "OpenClaw Comprehension", category: "core_agent" },
+    task_second_brain: { name: "Second Brain", category: "core_agent" },
+
+    task_image_gen: { name: "Image Generation", category: "creative" },
+    task_image_identification: { name: "Image Identification", category: "creative" },
   };
+
+const LEGACY_CATEGORY_MAP: Record<string, string> = {
+  api: "data_analysis",
+  validation: "core_agent",
+  calendar: "productivity",
+  research: "research_knowledge",
+  writing: "writing_content",
+  coding: "code_devops",
+  comprehension: "core_agent",
+  context: "core_agent",
+  complex: "core_agent",
+};
+
+const TASK_CATEGORY_PATTERNS: Array<{ pattern: RegExp; category: string }> = [
+  {
+    pattern: /(test_generation|k8s|cicd|dockerfile|selector_fix|refactor|playwright|git_rescue|weather|code)/,
+    category: "code_devops",
+  },
+  {
+    pattern: /(csv|spreadsheet|financial|earnings|stock|ratio|analysis)/,
+    category: "data_analysis",
+  },
+  {
+    pattern: /(blog|humanizer|readme|commit_message|summary|eli5|writing|content)/,
+    category: "writing_content",
+  },
+  {
+    pattern: /(calendar|email|todo|daily_summary|gws|pdf_to_calendar|productivity)/,
+    category: "productivity",
+  },
+  {
+    pattern: /(market_research|executive|polymarket|contract|skill_search|research|events)/,
+    category: "research_knowledge",
+  },
+  {
+    pattern: /(access_log|cve|security|gh_issue|triage|anomaly)/,
+    category: "security_ops",
+  },
+  {
+    pattern: /(sanity|memory|files|workflow|openclaw|second_brain|comprehension|context)/,
+    category: "core_agent",
+  },
+  {
+    pattern: /(image|creative)/,
+    category: "creative",
+  },
+];
+
+export function resolveTaskCategory(
+  taskId: string,
+  category?: string | null,
+): string {
+  const normalizedCategory = category?.trim().toLowerCase();
+  if (normalizedCategory) {
+    if (LEGACY_CATEGORY_MAP[normalizedCategory]) {
+      return LEGACY_CATEGORY_MAP[normalizedCategory];
+    }
+    if (
+      [
+        "code_devops",
+        "data_analysis",
+        "writing_content",
+        "productivity",
+        "research_knowledge",
+        "security_ops",
+        "core_agent",
+        "creative",
+      ].includes(normalizedCategory)
+    ) {
+      return normalizedCategory;
+    }
+  }
+
+  const normalizedTaskId = taskId.toLowerCase();
+  for (const { pattern, category: mappedCategory } of TASK_CATEGORY_PATTERNS) {
+    if (pattern.test(normalizedTaskId)) return mappedCategory;
+  }
+
+  return normalizedCategory || "other";
+}

--- a/lib/transforms.ts
+++ b/lib/transforms.ts
@@ -6,7 +6,7 @@ import type {
   Submission,
   TaskResult,
 } from "@/lib/types";
-import { TASK_FALLBACK } from "@/lib/task-metadata";
+import { resolveTaskCategory, TASK_FALLBACK } from "@/lib/task-metadata";
 
 const EPSILON = 1e-6;
 
@@ -112,8 +112,10 @@ export function transformTaskResult(apiTask: ApiTaskResult): TaskResult {
   const fallback = TASK_FALLBACK[apiTask.task_id];
   const taskName =
     apiTask.frontmatter?.name ?? fallback?.name ?? apiTask.task_id;
-  const category =
-    apiTask.frontmatter?.category ?? fallback?.category ?? "other";
+  const category = resolveTaskCategory(
+    apiTask.task_id,
+    apiTask.frontmatter?.category ?? fallback?.category,
+  );
 
   return {
     task_id: apiTask.task_id,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -242,7 +242,90 @@ export interface BenchmarkVersionsResponse {
 
 export type SortMode = "quality" | "value";
 
+export interface TaskCategory {
+  id: string;
+  label: string;
+  shortLabel: string;
+  icon: string;
+  description: string;
+}
+
+export const TASK_CATEGORIES: TaskCategory[] = [
+  {
+    id: "code_devops",
+    label: "Code & DevOps",
+    shortLabel: "Code",
+    icon: "🔧",
+    description: "Coding, automation, CI/CD, Kubernetes, Docker, tests, and refactors",
+  },
+  {
+    id: "data_analysis",
+    label: "Data & Analysis",
+    shortLabel: "Data",
+    icon: "📊",
+    description: "CSV, spreadsheet, market, earnings, and financial analysis tasks",
+  },
+  {
+    id: "writing_content",
+    label: "Writing & Content",
+    shortLabel: "Writing",
+    icon: "✍️",
+    description: "Blog posts, summaries, README generation, and content rewriting",
+  },
+  {
+    id: "productivity",
+    label: "Productivity",
+    shortLabel: "Productivity",
+    icon: "📅",
+    description: "Calendar, email, todo, daily summary, and workspace organization tasks",
+  },
+  {
+    id: "research_knowledge",
+    label: "Research & Knowledge",
+    shortLabel: "Research",
+    icon: "🔍",
+    description: "Market research, lookups, briefings, contract analysis, and skill search",
+  },
+  {
+    id: "security_ops",
+    label: "Security & Ops",
+    shortLabel: "Security",
+    icon: "🛡️",
+    description: "Security triage, anomaly detection, GitHub issue triage, and ops tasks",
+  },
+  {
+    id: "core_agent",
+    label: "Core Agent",
+    shortLabel: "Agent",
+    icon: "🤖",
+    description: "Sanity, memory, files, workflow, and OpenClaw comprehension tasks",
+  },
+  {
+    id: "creative",
+    label: "Creative",
+    shortLabel: "Creative",
+    icon: "🎨",
+    description: "Image generation, image identification, and creative tasks",
+  },
+];
+
+export const TASK_CATEGORY_BY_ID = TASK_CATEGORIES.reduce(
+  (acc, category) => {
+    acc[category.id] = category;
+    return acc;
+  },
+  {} as Record<string, TaskCategory>,
+);
+
 export const CATEGORY_ICONS: Record<string, string> = {
+  code_devops: "🔧",
+  data_analysis: "📊",
+  writing_content: "✍️",
+  productivity: "📅",
+  research_knowledge: "🔍",
+  security_ops: "🛡️",
+  core_agent: "🤖",
+  creative: "🎨",
   api: "🔌",
   validation: "✅",
   calendar: "📅",


### PR DESCRIPTION
## Summary

Re-implementation of #96 on current main (the original had too many conflicts to merge).

- Introduces 8 task categories with icons, labels, and pattern-matching normalization
- Adds `CategoryPills` reusable filter UI component
- Adds shared `category-scores.ts` utilities for score aggregation and filtering
- Leaderboard view fetches per-submission task data when categories are selected and recalculates scores
- Simple leaderboard adapts titles, bar chart, table for category-filtered mode
- Task heatmap uses shared `CategoryPills` and `getCategoryMeta` for consistent labels
- Submission page uses `aggregateCategoryScores` for category breakdown cards

Supersedes #96. Closes #86.