### PR TITLE
feat: base Best Overall & Best Open-Weights Quick Picks on average score

### DIFF
--- a/components/quick-picks.tsx
+++ b/components/quick-picks.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { RecommendationPick } from "@/lib/types";
-import { formatCost } from "@/lib/recommendations";
+import { formatCost, getAverageScorePercent } from "@/lib/recommendations";
 
 interface QuickPicksProps {
   picks: RecommendationPick[];
@@ -42,7 +42,7 @@ export function QuickPicks({ picks }: QuickPicksProps) {
             </code>
             <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
               <span>{pick.metricLabel}</span>
-              <span>{pick.entry.percentage.toFixed(1)}% overall · {formatCost(pick.entry.best_cost_usd)}</span>
+              <span>{(pick.useAverageScore ? getAverageScorePercent(pick.entry) : pick.entry.percentage).toFixed(1)}% overall · {formatCost(pick.entry.best_cost_usd)}</span>
             </div>
             <p className="mt-3 text-xs leading-relaxed text-muted-foreground">{pick.description}</p>
           </Link>

--- a/lib/recommendations.test.ts
+++ b/lib/recommendations.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { getAverageScorePercent, getQuickRecommendations } from "./recommendations";
+import type { EnrichedLeaderboardEntry } from "./types";
+
+function makeEntry(
+  overrides: Partial<EnrichedLeaderboardEntry> & { model: string },
+): EnrichedLeaderboardEntry {
+  return {
+    rank: 0,
+    provider: "test",
+    percentage: 0,
+    timestamp: "2026-01-01T00:00:00Z",
+    submission_id: `${overrides.model}-sub`,
+    categoryScores: [],
+    ...overrides,
+  };
+}
+
+describe("getAverageScorePercent", () => {
+  test("scales the 0-1 average to a 0-100 percentage", () => {
+    expect(
+      getAverageScorePercent(
+        makeEntry({ model: "m", percentage: 90, average_score_percentage: 0.85 }),
+      ),
+    ).toBeCloseTo(85);
+  });
+
+  test("falls back to the best percentage when no average exists", () => {
+    expect(
+      getAverageScorePercent(
+        makeEntry({ model: "m", percentage: 90, average_score_percentage: null }),
+      ),
+    ).toBe(90);
+  });
+});
+
+describe("getQuickRecommendations", () => {
+  test("Best Overall is chosen by average score, not max", () => {
+    const a = makeEntry({ model: "A", percentage: 95, average_score_percentage: 0.8 });
+    const b = makeEntry({ model: "B", percentage: 90, average_score_percentage: 0.88 });
+    const overall = getQuickRecommendations([a, b]).find((p) => p.key === "overall");
+    expect(overall?.entry.model).toBe("B");
+    expect(overall?.metricValue).toBe("88.0%");
+    expect(overall?.metricLabel).toBe("Average Score");
+    expect(overall?.useAverageScore).toBe(true);
+  });
+
+  test("Best Open Weights picks the highest-average open-weight model", () => {
+    const openLow = makeEntry({ model: "open-low", weights: "Open", percentage: 70, average_score_percentage: 0.6 });
+    const openHigh = makeEntry({ model: "open-high", weights: "Open", percentage: 65, average_score_percentage: 0.68 });
+    const closedTop = makeEntry({ model: "closed-top", weights: "Closed", percentage: 99, average_score_percentage: 0.95 });
+    const ow = getQuickRecommendations([closedTop, openLow, openHigh]).find((p) => p.key === "open-weights");
+    expect(ow?.entry.model).toBe("open-high");
+    expect(ow?.icon).toBe("🔓");
+    expect(ow?.metricLabel).toBe("Average Score");
+    expect(ow?.metricValue).toBe("68.0%");
+    expect(ow?.href).toBe("/?weights=open");
+    expect(ow?.useAverageScore).toBe(true);
+  });
+
+  test("Best Open Weights card is omitted when no open-weight model exists", () => {
+    const closed = makeEntry({ model: "c", weights: "Closed", percentage: 80, average_score_percentage: 0.75 });
+    expect(
+      getQuickRecommendations([closed]).find((p) => p.key === "open-weights"),
+    ).toBeUndefined();
+  });
+
+  test("Best Open Weights is positioned immediately after Best Overall", () => {
+    const open = makeEntry({ model: "open", weights: "Open", percentage: 60, average_score_percentage: 0.55 });
+    const a = makeEntry({ model: "A", percentage: 95, average_score_percentage: 0.9 });
+    const keys = getQuickRecommendations([a, open]).map((p) => p.key);
+    expect(keys.indexOf("open-weights")).toBe(keys.indexOf("overall") + 1);
+  });
+
+  test("Best Budget still selects by best cost (selection unchanged)", () => {
+    const x = makeEntry({ model: "X", average_score_percentage: 0.8, best_cost_usd: 0.1, average_cost_usd: 0.5 });
+    const y = makeEntry({ model: "Y", average_score_percentage: 0.8, best_cost_usd: 0.2, average_cost_usd: 0.15 });
+    const budget = getQuickRecommendations([x, y]).find((p) => p.key === "budget");
+    expect(budget?.entry.model).toBe("X");
+    expect(budget?.metricValue).toBe("$0.100");
+    expect(budget?.useAverageScore).toBeUndefined();
+  });
+});

--- a/lib/recommendations.ts
+++ b/lib/recommendations.ts
@@ -53,6 +53,17 @@ export function formatCost(cost: number | null | undefined): string {
   return `$${cost.toFixed(cost < 1 ? 3 : 2)}`;
 }
 
+/**
+ * Average success rate for a model on a 0-100 scale.
+ * `average_score_percentage` is stored on a 0-1 scale; fall back to the
+ * best/max `percentage` (already 0-100) when no average is available.
+ */
+export function getAverageScorePercent(entry: LeaderboardEntry): number {
+  return entry.average_score_percentage != null
+    ? entry.average_score_percentage * 100
+    : entry.percentage;
+}
+
 export function formatDuration(seconds: number | null | undefined): string {
   if (seconds == null) return "N/A";
   if (seconds >= 60) return `${(seconds / 60).toFixed(1)}m`;
@@ -161,7 +172,7 @@ export function getCategoryChampionBadges(entries: EnrichedLeaderboardEntry[]): 
 }
 
 export function getQuickRecommendations(entries: EnrichedLeaderboardEntry[]): RecommendationPick[] {
-  const bestOverall = [...entries].sort((a, b) => b.percentage - a.percentage)[0];
+  const bestOverall = [...entries].sort((a, b) => getAverageScorePercent(b) - getAverageScorePercent(a))[0];
   const fastest = [...entries]
     .filter((entry) => entry.best_execution_time_seconds != null)
     .sort((a, b) => (a.best_execution_time_seconds ?? Infinity) - (b.best_execution_time_seconds ?? Infinity))[0];
@@ -171,6 +182,9 @@ export function getQuickRecommendations(entries: EnrichedLeaderboardEntry[]): Re
   const bestValue = sortEntriesForBestFor(entries, "budget")[0];
   const bestCode = sortEntriesForBestFor(entries, "coding")[0];
   const bestData = sortEntriesForBestFor(entries, "data-analysis")[0];
+  const bestOpenWeights = [...entries]
+    .filter((entry) => entry.weights === "Open")
+    .sort((a, b) => getAverageScorePercent(b) - getAverageScorePercent(a))[0];
 
   const picks: Array<RecommendationPick | null | undefined> = [
     bestOverall && {
@@ -178,11 +192,24 @@ export function getQuickRecommendations(entries: EnrichedLeaderboardEntry[]): Re
       label: "Best Overall",
       shortLabel: "Overall",
       icon: "👑",
-      description: "Highest verified success rate across the benchmark.",
+      description: "Highest average across benchmark runs.",
       href: "/",
       entry: bestOverall,
-      metricLabel: "Score",
-      metricValue: `${bestOverall.percentage.toFixed(1)}%`,
+      metricLabel: "Average Score",
+      metricValue: `${getAverageScorePercent(bestOverall).toFixed(1)}%`,
+      useAverageScore: true,
+    },
+    bestOpenWeights && {
+      key: "open-weights",
+      label: "Best Open-Weights",
+      shortLabel: "Open-Weights",
+      icon: "🔓",
+      description: "Highest open-weights average across benchmark runs.",
+      href: "/?weights=open",
+      entry: bestOpenWeights,
+      metricLabel: "Average Score",
+      metricValue: `${getAverageScorePercent(bestOpenWeights).toFixed(1)}%`,
+      useAverageScore: true,
     },
     fastest && {
       key: "speed",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,6 +46,8 @@ export interface RecommendationPick {
   entry: LeaderboardEntry;
   metricLabel: string;
   metricValue: string;
+  /** When true, the card's "% overall" subtitle shows the average score instead of the best/max. */
+  useAverageScore?: boolean;
 }
 
 export interface TaskResult {


### PR DESCRIPTION
## Summary
  Adds a **Best Open-Weights** Quick Pick and switches the score-ranked Quick Picks from best/max score to **average** score.

  ## Changes
  - **New "Best Open-Weights" card** (🔓, 2nd position) — picks the highest *average*-scoring open-weight model (`weights: "Open"`), labeled **Average Score**, links to
  `/?weights=open`. Description: *"Highest open-weights average across benchmark runs."*
  - **Best Overall** now selects *and* displays by average score — both the badge and the "% overall" subtitle — relabeled **Average Score**, with its description updated to *"Highest
  average across benchmark runs."*
  - **Fastest / Best Budget / Best Value / Code / Data are unchanged** — their selection and their "% overall" subtitle still use best/max score.

  ## Implementation
  - New `getAverageScorePercent()` helper in `lib/recommendations.ts` — converts the API's 0–1 `average_score_percentage` to a 0–100 value, falling back to the max `percentage` when
  no average exists.
  - A `useAverageScore` flag on `RecommendationPick` gates the average-vs-max subtitle per card, so only the two intended cards change.

  ## Testing
  - New `lib/recommendations.test.ts` (7 tests): average-based Best Overall selection, open-weight filtering/selection, card omitted when no open-weight model exists, null-average
  fallback, and a guard that Best Budget still ranks by best cost.
  - Full suite: **114/114 pass**; changed files typecheck clean.