### PR TITLE
Make leaderboard API origin configurable

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,24 @@
+name: Secret Scanning
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  trufflehog:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Secret Scanning
+        uses: trufflesecurity/trufflehog@7f4e37db2d928c18ddd7ddf0604f8f7d1f5793ec # v3.93.0
+        with:
+          extra_args: --results=verified,unknown

--- a/app/claim/page.tsx
+++ b/app/claim/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   description: 'Link your GitHub account to claim your PinchBench submissions on the leaderboard.',
 }
 
-const API_BASE = 'https://api.pinchbench.com/api'
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.pinchbench.com/api'
 
 interface ClaimPageProps {
   searchParams: Promise<{ token?: string }>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -11,7 +11,7 @@ import type {
 } from "@/lib/types";
 import { transformSubmission } from "@/lib/transforms";
 
-const API_BASE = "https://api.pinchbench.com/api";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "https://api.pinchbench.com/api";
 const SUBMISSION_DETAIL_REVALIDATE_SECONDS = 60;
 
 interface OfficialFilterOptions {


### PR DESCRIPTION
## Summary
- allow Vercel Preview deployments to target an alternate API with `NEXT_PUBLIC_API_URL`
- retain `https://api.pinchbench.com/api` as the production default
- use the same configurable origin for GitHub claim links
- add the standard pinned TruffleHog secret-scanning workflow

## Validation
- `bun test` (118 tests passed)
- `NEXT_PUBLIC_API_URL=https://pinchbench-api.engineering-e11.workers.dev/api bun run build`
- workflow YAML syntax parsed successfully