### PR TITLE
Remove personal social links from footer and about page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ PinchBench Leaderboard is the public frontend at https://pinchbench.com. It disp
 
 This repo is one of three components:
 
-- **pinchbench-skill** (github.com/olearycrew/pinchbench-skill): runs benchmarks against LLMs using OpenClaw, uploads results
+- **pinchbench-skill** (github.com/pinchbench/skill): runs benchmarks against LLMs using OpenClaw, uploads results
 - **pinchbench-api** (api.pinchbench.com): backend API that stores and serves all benchmark data; has an admin section at /admin used by the system owner
 - **pinchbench-leaderboard** (this repo, pinchbench.com): Next.js frontend, reads from the API
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -463,15 +463,6 @@ export default function AboutPage() {
                             <ExternalLink className="h-4 w-4" />
                             <span>Kilo Code</span>
                         </a>
-                        <a
-                            href="https://boleary.dev"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
-                        >
-                            <ExternalLink className="h-4 w-4" />
-                            <span>boleary.dev</span>
-                        </a>
                     </div>
                 </section>
             </div>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -40,16 +40,6 @@ export function Footer() {
                         </a>
                         <span className="text-border hidden md:inline">|</span>
                         <a
-                            href="https://boleary.dev"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-                        >
-                            <ExternalLink className="h-3.5 w-3.5" />
-                            <span>boleary.dev</span>
-                        </a>
-                        <span className="text-border hidden md:inline">|</span>
-                        <a
                             href="https://kilo.ai"
                             target="_blank"
                             rel="noopener noreferrer"
@@ -74,23 +64,6 @@ export function Footer() {
                                 <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
                             </svg>
                             <span>@pinchbench</span>
-                        </a>
-                        <span className="text-border hidden md:inline">|</span>
-                        <a
-                            href="https://x.com/olearycrew"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-                        >
-                            <svg
-                                className="h-3.5 w-3.5"
-                                viewBox="0 0 24 24"
-                                fill="currentColor"
-                                aria-hidden="true"
-                            >
-                                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                            </svg>
-                            <span>@olearycrew</span>
                         </a>
                     </div>
 

--- a/components/kiloclaw-ad-card.tsx
+++ b/components/kiloclaw-ad-card.tsx
@@ -4,13 +4,15 @@ import { usePostHog } from 'posthog-js/react'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 
+const KILO_URL = 'https://kilo.ai?utm_source=pinchbench&utm_medium=referral'
+
 export function KiloClawAdCard() {
     const posthog = usePostHog()
 
     const handleClick = () => {
-        posthog?.capture('kiloclaw_cta_click', {
+        posthog?.capture('kilo_cta_click', {
             location: 'ad_card',
-            destination: 'https://app.kilo.ai/claw',
+            destination: KILO_URL,
         })
     }
 
@@ -21,28 +23,20 @@ export function KiloClawAdCard() {
                     <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-[#F8F675]/50 bg-[#F8F675]/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-[#F8F675]">
                         <span>Totally An Ad</span>
                     </div>
-                    <div className="flex gap-8 flex-col lg:flex-row">
-                        <div className="flex-shrink">
-                            <p className="text-lg font-semibold text-foreground">
-                                Hosted OpenClaw — your personal AI agent, managed by Kilo.
-                            </p>
-                            <p className="mt-1 text-sm text-muted-foreground">
-                                Hosting and inference cost for PinchBench sponsored by Kilo, so we totally hope you try KiloClaw so we can keep the lights on around here.
-                            </p>
-                        </div>
-                        <p className="mt-1 flex-grow lg:min-w-[350px]">
-                            $55/month
-                            + AI inference at cost
-                        </p>
-                    </div>
+                    <p className="text-lg font-semibold text-foreground">
+                        The open source AI coding agent with 500+ models.
+                    </p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Hosting and inference for PinchBench is sponsored by Kilo, so we totally hope you try kilo.ai so we can keep the lights on around here.
+                    </p>
                 </div>
                 <Button
                     asChild
                     size="sm"
                     className="w-full border border-[#F8F675] bg-[#F8F675] text-black hover:bg-[#e6e45f] md:w-auto"
                 >
-                    <a href="https://app.kilo.ai/claw" target="_blank" rel="noopener noreferrer" onClick={handleClick}>
-                        Try KiloClaw
+                    <a href={KILO_URL} target="_blank" rel="noopener noreferrer" onClick={handleClick}>
+                        Try Kilo
                     </a>
                 </Button>
             </div>


### PR DESCRIPTION
## Summary
- Remove `boleary.dev` and `@olearycrew` from the footer
- Remove the `boleary.dev` related link on the About page
- Update the remaining skill repo reference in `AGENTS.md` to https://github.com/pinchbench/skill

## Test plan
- [x] Confirm footer no longer shows boleary.dev or @olearycrew
- [x] Confirm About page related links no longer include boleary.dev
- [x] Confirm GitHub, kilo.ai, and @pinchbench links still render