### PR TITLE
Fix empty top 5 on /best-for/data-analysis

### DIFF
--- a/lib/recommendations.test.ts
+++ b/lib/recommendations.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { getAverageScorePercent, getQuickRecommendations } from "./recommendations";
+import {
+  getAverageScorePercent,
+  getBestForConfig,
+  getQuickRecommendations,
+  sortEntriesForBestFor,
+} from "./recommendations";
 import type { EnrichedLeaderboardEntry } from "./types";
 
 function makeEntry(
@@ -79,5 +84,54 @@ describe("getQuickRecommendations", () => {
     expect(budget?.entry.model).toBe("X");
     expect(budget?.metricValue).toBe("$0.100");
     expect(budget?.useAverageScore).toBeUndefined();
+  });
+});
+
+describe("sortEntriesForBestFor", () => {
+  test("data-analysis ranks models by data_analysis category score", () => {
+    const weakData = makeEntry({
+      model: "weak-data",
+      percentage: 90,
+      categoryScores: [{ category: "data_analysis", scorePercentage: 40, taskCount: 4 }],
+    });
+    const strongData = makeEntry({
+      model: "strong-data",
+      percentage: 70,
+      categoryScores: [{ category: "data_analysis", scorePercentage: 95, taskCount: 4 }],
+    });
+    const noData = makeEntry({
+      model: "no-data",
+      percentage: 99,
+      categoryScores: [{ category: "code_devops", scorePercentage: 100, taskCount: 8 }],
+    });
+
+    const ranked = sortEntriesForBestFor([weakData, noData, strongData], "data-analysis");
+    expect(ranked.map((entry) => entry.model)).toEqual(["strong-data", "weak-data"]);
+  });
+
+  test("coding ranks models by code_devops category score", () => {
+    const ranked = sortEntriesForBestFor(
+      [
+        makeEntry({
+          model: "coder",
+          percentage: 60,
+          categoryScores: [{ category: "code_devops", scorePercentage: 88, taskCount: 8 }],
+        }),
+        makeEntry({
+          model: "analyst",
+          percentage: 95,
+          categoryScores: [{ category: "data_analysis", scorePercentage: 99, taskCount: 4 }],
+        }),
+      ],
+      "coding",
+    );
+    expect(ranked.map((entry) => entry.model)).toEqual(["coder"]);
+  });
+});
+
+describe("BEST_FOR_CATEGORIES", () => {
+  test("maps landing-page slugs to current task category ids", () => {
+    expect(getBestForConfig("data-analysis")?.category).toBe("data_analysis");
+    expect(getBestForConfig("coding")?.category).toBe("code_devops");
   });
 });

--- a/lib/recommendations.ts
+++ b/lib/recommendations.ts
@@ -11,23 +11,23 @@ import { CATEGORY_ICONS } from "@/lib/types";
 export const BEST_FOR_CATEGORIES = [
   {
     slug: "coding",
-    category: "coding",
+    category: "code_devops",
     title: `Best AI Model for Coding in ${new Date().getFullYear()}`,
     navLabel: "Coding",
     description:
       "Compare the leading AI coding agents on PinchBench tasks that require writing scripts, editing files, and completing developer workflows.",
     taskSummary:
-      "Coding pages focus on benchmark tasks categorized as coding, including script generation and file operations. Scores come from the best verified submission for each model.",
+      "Coding pages focus on code and DevOps benchmark tasks, including script generation, refactors, and CI/CD work. Scores come from the best verified submission for each model.",
   },
   {
     slug: "data-analysis",
-    category: "api",
+    category: "data_analysis",
     title: "Best AI for Data Analysis",
     navLabel: "Data Analysis",
     description:
-      "Find models that perform well on data-oriented research and API tasks where the agent must gather, transform, and present structured information.",
+      "Find models that perform well on data-oriented research and analysis tasks where the agent must gather, transform, and present structured information.",
     taskSummary:
-      "Data analysis uses API and data-retrieval tasks as the closest available PinchBench proxy for structured data work.",
+      "Data analysis uses spreadsheet, financial, CSV, and related data-retrieval tasks as the PinchBench proxy for structured data work.",
   },
   {
     slug: "budget",
@@ -249,22 +249,22 @@ export function getQuickRecommendations(entries: EnrichedLeaderboardEntry[]): Re
       label: "Best for Code",
       shortLabel: "Code",
       icon: "🔧",
-      description: "Highest score on coding-category tasks.",
+      description: "Highest score on code and DevOps tasks.",
       href: "/best-for/coding",
       entry: bestCode,
       metricLabel: "Coding Score",
-      metricValue: `${getCategoryScore(bestCode, "coding")?.scorePercentage.toFixed(1) ?? bestCode.percentage.toFixed(1)}%`,
+      metricValue: `${getCategoryScore(bestCode, "code_devops")?.scorePercentage.toFixed(1) ?? bestCode.percentage.toFixed(1)}%`,
     },
     bestData && {
       key: "data",
       label: "Best for Data",
       shortLabel: "Data",
       icon: "📊",
-      description: "Highest score on data-oriented API tasks.",
+      description: "Highest score on data analysis tasks.",
       href: "/best-for/data-analysis",
       entry: bestData,
       metricLabel: "Data Score",
-      metricValue: `${getCategoryScore(bestData, "api")?.scorePercentage.toFixed(1) ?? bestData.percentage.toFixed(1)}%`,
+      metricValue: `${getCategoryScore(bestData, "data_analysis")?.scorePercentage.toFixed(1) ?? bestData.percentage.toFixed(1)}%`,
     },
   ];
 


### PR DESCRIPTION
## Summary
- `/best-for/data-analysis` ranked models on the legacy `api` category, but transformed task results now use `data_analysis`. `sortEntriesForBestFor` dropped every entry, so the Top 5 comparison stayed empty.
- Point coding and data-analysis recommendations at `code_devops` and `data_analysis`, matching `resolveTaskCategory` / `TASK_CATEGORIES`.
- Cover ranking with unit tests so a category-id drift fails before the table goes blank again.

## Test plan
- [ ] `bun test lib/recommendations.test.ts`
- [ ] Open `/best-for/data-analysis` and confirm the Top 5 comparison has five rows with use-case scores
- [ ] Confirm `/best-for/coding` still ranks models (it had the same `coding` vs `code_devops` mismatch)
- [ ] Confirm homepage quick picks still show Best for Data / Best for Code
